### PR TITLE
feat: Date::parse and Date::format (YYYY-MM-DD)

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -18,7 +18,9 @@ pub struct Date {
   month : Int
   day : Int
 }
+pub fn Date::format(Self) -> String
 pub fn Date::new(Int, Int, Int) -> Self raise TempoError
+pub fn Date::parse(String) -> Self raise TempoError
 pub impl Compare for Date
 pub impl Eq for Date
 pub impl Show for Date

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -122,6 +122,28 @@ pub fn Date::new(year : Int, month : Int, day : Int) -> Date raise TempoError {
 }
 
 ///|
+/// Parse a calendar date in 'YYYY-MM-DD' format.
+pub fn Date::parse(s : String) -> Date raise TempoError {
+  let v = s.view()
+  let (year, v) = parse_digits(v, 4)
+  let v = consume(v, '-')
+  let (month, v) = parse_digits(v, 2)
+  let v = consume(v, '-')
+  let (day, v) = parse_digits(v, 2)
+  match v {
+    [] => ()
+    _ => raise TempoError("unexpected trailing characters")
+  }
+  Date::new(year, month, day)
+}
+
+///|
+/// Format this date as 'YYYY-MM-DD'.
+pub fn Date::format(self : Date) -> String {
+  "\{pad4(self.year)}-\{pad2(self.month)}-\{pad2(self.day)}"
+}
+
+///|
 pub fn Time::new(
   hour : Int,
   minute : Int,

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -54,6 +54,49 @@ test "Date::new non-leap Feb 29 invalid" {
 }
 
 ///|
+test "Date::parse valid" {
+  let d = @src.Date::parse("2024-03-15")
+  assert_eq(d.year, 2024)
+  assert_eq(d.month, 3)
+  assert_eq(d.day, 15)
+}
+
+///|
+test "Date::format" {
+  let d = @src.Date::new(2024, 3, 5)
+  assert_eq(d.format(), "2024-03-05")
+}
+
+///|
+test "Date::parse roundtrip" {
+  let s = "2000-02-29"
+  let d = @src.Date::parse(s)
+  assert_eq(d.format(), s)
+}
+
+///|
+test "Date::parse invalid month" {
+  let result = try {
+    @src.Date::parse("2024-13-01") |> ignore
+    "ok"
+  } catch {
+    @src.TempoError(_) => "error"
+  }
+  assert_eq(result, "error")
+}
+
+///|
+test "Date::parse trailing junk" {
+  let result = try {
+    @src.Date::parse("2024-01-01Z") |> ignore
+    "ok"
+  } catch {
+    @src.TempoError(_) => "error"
+  }
+  assert_eq(result, "error")
+}
+
+///|
 test "Time::new valid" {
   let t = @src.Time::new(23, 59, 59, 999_999_999)
   assert_eq(t.hour, 23)


### PR DESCRIPTION
Adds `Date::parse` for ISO 8601 calendar dates (`YYYY-MM-DD`) using the existing `parse_digits` and `consume` helpers, and `Date::format` producing the same shape via `pad4`/`pad2`. Invalid dates are rejected through `Date::new`.

Tests cover happy path, format output, roundtrip, invalid month, and trailing characters.

Verified: `moon fmt --check`, `moon test` on native, js, and wasm-gc.

Closes #6.