### PR TITLE
feat: Time::parse and Time::format (closes #7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.cursor/
 _build/
 .mooncakes/
 .moonagent/

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -72,7 +72,9 @@ pub struct Time {
   second : Int
   nanosecond : Int
 }
+pub fn Time::format(Self) -> String
 pub fn Time::new(Int, Int, Int, Int) -> Self raise TempoError
+pub fn Time::parse(String) -> Self raise TempoError
 pub impl Compare for Time
 pub impl Eq for Time
 pub impl Show for Time

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -395,6 +395,18 @@ pub fn DateTime::format(self : DateTime) -> String {
 }
 
 ///|
+/// Format this time as `HH:MM:SS` or `HH:MM:SS.fraction` (nanoseconds trimmed,
+/// consistent with `DateTime::format`).
+pub fn Time::format(self : Time) -> String {
+  let base = "\{pad2(self.hour)}:\{pad2(self.minute)}:\{pad2(self.second)}"
+  if self.nanosecond == 0 {
+    base
+  } else {
+    base + "." + fmt_frac(self.nanosecond)
+  }
+}
+
+///|
 pub impl Show for Date with output(self, logger) {
   logger.write_string(
     "\{pad4(self.year)}-\{pad2(self.month)}-\{pad2(self.day)}",
@@ -577,4 +589,24 @@ pub fn DateTime::parse(s : String) -> DateTime raise TempoError {
   let date = Date::new(year, month, day)
   let time = Time::new(hour, minute, second, nanosecond)
   { date, time }
+}
+
+///|
+/// Parse a time-of-day string: `HH:MM:SS` or `HH:MM:SS.fraction`.
+pub fn Time::parse(s : String) -> Time raise TempoError {
+  let v = s.view()
+  let (hour, v) = parse_digits(v, 2)
+  let v = consume(v, ':')
+  let (minute, v) = parse_digits(v, 2)
+  let v = consume(v, ':')
+  let (second, v) = parse_digits(v, 2)
+  let (nanosecond, v) = match v {
+    ['.', .. rest] => parse_frac_ns(rest)
+    _ => (0, v)
+  }
+  match v {
+    [] => ()
+    _ => raise TempoError("unexpected trailing characters")
+  }
+  Time::new(hour, minute, second, nanosecond)
 }

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -415,12 +415,7 @@ pub impl Show for Date with output(self, logger) {
 
 ///|
 pub impl Show for Time with output(self, logger) {
-  let base = "\{pad2(self.hour)}:\{pad2(self.minute)}:\{pad2(self.second)}"
-  if self.nanosecond == 0 {
-    logger.write_string(base)
-  } else {
-    logger.write_string(base + "." + fmt_frac(self.nanosecond))
-  }
+  logger.write_string(self.format())
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -189,6 +189,98 @@ test "DateTime::format nanosecond precision" {
 }
 
 ///|
+test "Time::format no sub-second" {
+  let t = @src.Time::new(0, 0, 0, 0)
+  assert_eq(t.format(), "00:00:00")
+}
+
+///|
+test "Time::format with nanoseconds trimmed" {
+  let t = @src.Time::new(12, 34, 56, 100_000_000)
+  assert_eq(t.format(), "12:34:56.1")
+}
+
+///|
+test "Time::format nanosecond precision" {
+  let t = @src.Time::new(12, 34, 56, 123_456_789)
+  assert_eq(t.format(), "12:34:56.123456789")
+}
+
+///|
+test "Time::parse basic" {
+  let t = @src.Time::parse("12:34:56")
+  assert_eq(t.hour, 12)
+  assert_eq(t.minute, 34)
+  assert_eq(t.second, 56)
+  assert_eq(t.nanosecond, 0)
+}
+
+///|
+test "Time::parse midnight" {
+  let t = @src.Time::parse("00:00:00")
+  assert_eq(t.hour, 0)
+  assert_eq(t.nanosecond, 0)
+}
+
+///|
+test "Time::parse with fractional seconds" {
+  let t = @src.Time::parse("12:34:56.123456789")
+  assert_eq(t.nanosecond, 123_456_789)
+}
+
+///|
+test "Time::parse fractional seconds trimmed" {
+  let t = @src.Time::parse("12:34:56.1")
+  assert_eq(t.nanosecond, 100_000_000)
+}
+
+///|
+test "Time::parse fractional seconds >9 digits truncated" {
+  let t = @src.Time::parse("12:34:56.123456789999")
+  assert_eq(t.nanosecond, 123_456_789)
+}
+
+///|
+test "Time::parse invalid hour" {
+  let result = try {
+    @src.Time::parse("24:00:00") |> ignore
+    "ok"
+  } catch {
+    @src.TempoError(_) => "error"
+  }
+  assert_eq(result, "error")
+}
+
+///|
+test "Time::parse invalid format" {
+  let result = try {
+    @src.Time::parse("not-a-time") |> ignore
+    "ok"
+  } catch {
+    @src.TempoError(_) => "error"
+  }
+  assert_eq(result, "error")
+}
+
+///|
+test "Time::parse unexpected trailing" {
+  let result = try {
+    @src.Time::parse("12:34:56Z") |> ignore
+    "ok"
+  } catch {
+    @src.TempoError(_) => "error"
+  }
+  assert_eq(result, "error")
+}
+
+///|
+test "Time::parse roundtrip" {
+  let s = "12:34:56.123456789"
+  let t = @src.Time::parse(s)
+  assert_eq(t.format(), s)
+}
+
+///|
 test "DateTime::parse basic" {
   let dt = @src.DateTime::parse("1970-01-01T00:00:00Z")
   assert_eq(dt.to_unix_seconds(), 0L)


### PR DESCRIPTION
Adds `Time::parse` for `HH:MM:SS` and `HH:MM:SS.fraction`, and `Time::format` using the same fractional rules as `DateTime::format` (`fmt_frac`, trailing zeros trimmed). Reuses `parse_digits`, `consume`, `parse_frac_ns`, and `Time::new` for validation.

Tests cover formatting, parsing, fractions, truncation past 9 digits, invalid input, and roundtrip.