### PR TITLE
feat(duration): add Duration::weeks and as_weeks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _build/
 .mooncakes/
 .moonagent/
+.cursor/

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -52,6 +52,7 @@ pub fn Duration::as_milliseconds(Self) -> Int64
 pub fn Duration::as_minutes(Self) -> Int64
 pub fn Duration::as_nanoseconds(Self) -> Int64
 pub fn Duration::as_seconds(Self) -> Int64
+pub fn Duration::as_weeks(Self) -> Int64
 pub fn Duration::days(Int64) -> Self
 pub fn Duration::hours(Int64) -> Self
 pub fn Duration::microseconds(Int64) -> Self
@@ -59,6 +60,7 @@ pub fn Duration::milliseconds(Int64) -> Self
 pub fn Duration::minutes(Int64) -> Self
 pub fn Duration::nanoseconds(Int64) -> Self
 pub fn Duration::seconds(Int64) -> Self
+pub fn Duration::weeks(Int64) -> Self
 pub impl Add for Duration
 pub impl Compare for Duration
 pub impl Eq for Duration

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -224,6 +224,11 @@ pub fn Duration::days(d : Int64) -> Duration {
 }
 
 ///|
+pub fn Duration::weeks(w : Int64) -> Duration {
+  { nanoseconds: w * 7L * 86_400L * ns_per_sec }
+}
+
+///|
 pub fn Duration::microseconds(us : Int64) -> Duration {
   { nanoseconds: us * ns_per_us }
 }
@@ -278,6 +283,11 @@ pub fn Duration::as_minutes(self : Duration) -> Int64 {
 ///|
 pub fn Duration::as_hours(self : Duration) -> Int64 {
   self.nanoseconds / ns_per_hour
+}
+
+///|
+pub fn Duration::as_weeks(self : Duration) -> Int64 {
+  self.nanoseconds / (7L * 86_400L * ns_per_sec)
 }
 
 // ─── Duration arithmetic ──────────────────────────────────────────────────────

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -280,6 +280,21 @@ test "Duration::days" {
 }
 
 ///|
+test "Duration::weeks" {
+  let w = @src.Duration::weeks(2L)
+  assert_eq(w.as_nanoseconds(), 2L * 7L * 86_400L * 1_000_000_000L)
+  assert_eq(w.as_seconds(), 2L * 7L * 86_400L)
+  assert_eq(w.as_weeks(), 2L)
+}
+
+///|
+test "Duration::as_weeks" {
+  assert_eq(@src.Duration::days(14L).as_weeks(), 2L)
+  assert_eq(@src.Duration::days(13L).as_weeks(), 1L)
+  assert_eq(@src.Duration::days(1L).as_weeks(), 0L)
+}
+
+///|
 test "Duration::days arithmetic" {
   let dt = @src.DateTime::parse("2024-01-31T00:00:00Z")
   let dt2 = dt.add(@src.Duration::days(1L))


### PR DESCRIPTION
Adds `Duration::weeks(Int64) -> Duration` using `7 * 86_400 * ns_per_sec`, and `Duration::as_weeks` for integer division back to weeks (same truncation behavior as other unit accessors).

Blackbox tests cover constructor equality with nanoseconds, `as_weeks` roundtrip, and partial-week truncation.

Also adds `.cursor/` to `.gitignore` so local Cursor metadata does not block PR tooling in worktrees.

Closes #4.