### PR TITLE
Add Date arithmetic (add_days, day_of_week, day_of_year, days_until)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _build/
 .mooncakes/
 .moonagent/
+.cursor/

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -18,6 +18,10 @@ pub struct Date {
   month : Int
   day : Int
 }
+pub fn Date::add_days(Self, Int) -> Self
+pub fn Date::day_of_week(Self) -> Int
+pub fn Date::day_of_year(Self) -> Int
+pub fn Date::days_until(Self, Self) -> Int
 pub fn Date::new(Int, Int, Int) -> Self raise TempoError
 pub impl Compare for Date
 pub impl Eq for Date

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -121,6 +121,47 @@ pub fn Date::new(year : Int, month : Int, day : Int) -> Date raise TempoError {
   { year, month, day }
 }
 
+// ─── Date arithmetic ──────────────────────────────────────────────────────────
+
+///|
+/// Add a signed number of calendar days to this date (proleptic Gregorian).
+pub fn Date::add_days(self : Date, days : Int) -> Date {
+  let base = days_from_civil(self.year, self.month, self.day)
+  let (y, m, d) = civil_from_days(base + days.to_int64())
+  { year: y, month: m, day: d }
+}
+
+///|
+/// ISO 8601 weekday: Monday = 1 through Sunday = 7.
+pub fn Date::day_of_week(self : Date) -> Int {
+  let d = days_from_civil(self.year, self.month, self.day)
+  // Align so Monday (1970-01-05, etc.) is remainder 0.
+  let idx = floor_mod64(d - 4L, 7L)
+  idx.to_int() + 1
+}
+
+///|
+/// Day of year in 1..366 (1 = January 1).
+pub fn Date::day_of_year(self : Date) -> Int {
+  let y = self.year
+  let start = days_from_civil(y, 1, 1)
+  let today = days_from_civil(self.year, self.month, self.day)
+  (today - start).to_int() + 1
+}
+
+///|
+/// Calendar days from `self` to `other` (`other` minus `self`). Negative if `other` is earlier.
+pub fn Date::days_until(self : Date, other : Date) -> Int {
+  let a = days_from_civil(self.year, self.month, self.day)
+  let b = days_from_civil(other.year, other.month, other.day)
+  (b - a).to_int()
+}
+
+///|
+fn floor_mod64(a : Int64, b : Int64) -> Int64 {
+  a - floor_div64(a, b) * b
+}
+
 ///|
 pub fn Time::new(
   hour : Int,

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -54,6 +54,65 @@ test "Date::new non-leap Feb 29 invalid" {
 }
 
 ///|
+test "Date::add_days forward" {
+  let d = @src.Date::new(2024, 3, 15)
+  let d2 = d.add_days(10)
+  assert_eq(d2.year, 2024)
+  assert_eq(d2.month, 3)
+  assert_eq(d2.day, 25)
+}
+
+///|
+test "Date::add_days backward" {
+  let d = @src.Date::new(2024, 3, 15)
+  let d2 = d.add_days(-14)
+  assert_eq(d2.month, 3)
+  assert_eq(d2.day, 1)
+}
+
+///|
+test "Date::add_days crosses month" {
+  let d = @src.Date::new(2024, 1, 31)
+  let d2 = d.add_days(1)
+  assert_eq(d2.month, 2)
+  assert_eq(d2.day, 1)
+}
+
+///|
+test "Date::add_days leap day" {
+  let d = @src.Date::new(2024, 2, 28)
+  let d2 = d.add_days(1)
+  assert_eq(d2.month, 2)
+  assert_eq(d2.day, 29)
+}
+
+///|
+test "Date::day_of_week ISO" {
+  // 1970-01-01 Thursday; 2024-01-01 Monday; 2024-03-15 Friday
+  assert_eq(@src.Date::new(1970, 1, 1).day_of_week(), 4)
+  assert_eq(@src.Date::new(2024, 1, 1).day_of_week(), 1)
+  assert_eq(@src.Date::new(2024, 3, 15).day_of_week(), 5)
+  assert_eq(@src.Date::new(2024, 3, 17).day_of_week(), 7)
+}
+
+///|
+test "Date::day_of_year" {
+  assert_eq(@src.Date::new(2024, 1, 1).day_of_year(), 1)
+  assert_eq(@src.Date::new(2024, 3, 15).day_of_year(), 75)
+  assert_eq(@src.Date::new(2023, 12, 31).day_of_year(), 365)
+  assert_eq(@src.Date::new(2024, 12, 31).day_of_year(), 366)
+}
+
+///|
+test "Date::days_until" {
+  let a = @src.Date::new(2024, 3, 1)
+  let b = @src.Date::new(2024, 3, 15)
+  assert_eq(a.days_until(b), 14)
+  assert_eq(b.days_until(a), -14)
+  assert_eq(a.days_until(a), 0)
+}
+
+///|
 test "Time::new valid" {
   let t = @src.Time::new(23, 59, 59, 999_999_999)
   assert_eq(t.hour, 23)


### PR DESCRIPTION
Adds calendar operations on `Date` using the existing Howard Hinnant civil day helpers:

- `Date::add_days` shifts by signed whole days in the proleptic Gregorian calendar.
- `Date::day_of_week` returns ISO 8601 weekday (Monday = 1, Sunday = 7).
- `Date::day_of_year` returns 1–366.
- `Date::days_until` is `other − self` in calendar days (negative when `other` is earlier).

Includes blackbox tests for edge cases (leap day, month boundaries, ISO weekday samples).

Closes #3.