### PR TITLE
fix: pad negative years to four digits in ISO 8601 output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cursor/
 .DS_Store
 _build/
 .mooncakes/

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -1,3 +1,7 @@
+import {
+  "moonbitlang/core/int",
+}
+
 options(
   targets: {
     "now_js.mbt": [ "js" ],

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -345,11 +345,20 @@ fn pad4(n : Int) -> String {
   }
 }
 
-// Year field for ISO 8601 / RFC 3339: sign plus four-digit absolute value.
+// Proleptic Gregorian year for text output: optional leading `-` for years
+// before 1 CE, then the absolute year number zero-padded to at least four
+// decimal digits (same rules as `pad4`). Years with |year| ≥ 10000 use more
+// than four digits. RFC 3339 `date-time` only allows four-digit positive years;
+// this formatting follows ISO 8601-style expanded years for arbitrary `Date`
+// values. `Int::min_value` cannot be negated to a positive `Int`; that case is
+// rejected here.
 
 ///|
 fn pad4_year(year : Int) -> String {
   if year < 0 {
+    if year == @int.min_value {
+      abort("pad4_year: year is Int::min_value, cannot format magnitude")
+    }
     "-" + pad4(-year)
   } else {
     pad4(year)
@@ -392,8 +401,10 @@ fn fmt_frac(ns : Int) -> String {
 }
 
 ///|
-/// Format this DateTime as an RFC 3339 / ISO 8601 string (UTC, 'Z' suffix).
-/// Sub-second precision is included only when nanoseconds ≠ 0.
+/// Format this DateTime as an RFC 3339-style string (UTC, `Z` suffix) when the
+/// year is in the usual four-digit range; negative years and years ≥ 10000 use
+/// ISO 8601 expanded-year conventions (see `pad4_year`). Sub-second precision
+/// is included only when nanoseconds ≠ 0.
 pub fn DateTime::format(self : DateTime) -> String {
   let d = self.date
   let t = self.time

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -345,6 +345,17 @@ fn pad4(n : Int) -> String {
   }
 }
 
+// Year field for ISO 8601 / RFC 3339: sign plus four-digit absolute value.
+
+///|
+fn pad4_year(year : Int) -> String {
+  if year < 0 {
+    "-" + pad4(-year)
+  } else {
+    pad4(year)
+  }
+}
+
 ///|
 fn pad9(n : Int) -> String {
   if n < 10 {
@@ -386,7 +397,7 @@ fn fmt_frac(ns : Int) -> String {
 pub fn DateTime::format(self : DateTime) -> String {
   let d = self.date
   let t = self.time
-  let base = "\{pad4(d.year)}-\{pad2(d.month)}-\{pad2(d.day)}T\{pad2(t.hour)}:\{pad2(t.minute)}:\{pad2(t.second)}"
+  let base = "\{pad4_year(d.year)}-\{pad2(d.month)}-\{pad2(d.day)}T\{pad2(t.hour)}:\{pad2(t.minute)}:\{pad2(t.second)}"
   if t.nanosecond == 0 {
     base + "Z"
   } else {
@@ -397,7 +408,7 @@ pub fn DateTime::format(self : DateTime) -> String {
 ///|
 pub impl Show for Date with output(self, logger) {
   logger.write_string(
-    "\{pad4(self.year)}-\{pad2(self.month)}-\{pad2(self.day)}",
+    "\{pad4_year(self.year)}-\{pad2(self.month)}-\{pad2(self.day)}",
   )
 }
 

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -189,6 +189,22 @@ test "DateTime::format nanosecond precision" {
 }
 
 ///|
+test "DateTime::format negative year" {
+  let d = @src.Date::new(-500, 6, 15)
+  let t = @src.Time::new(12, 0, 0, 0)
+  let dt = @src.DateTime::new(d, t)
+  assert_eq(dt.format(), "-0500-06-15T12:00:00Z")
+}
+
+///|
+test "DateTime::format negative year -0001" {
+  let d = @src.Date::new(-1, 1, 1)
+  let t = @src.Time::new(0, 0, 0, 0)
+  let dt = @src.DateTime::new(d, t)
+  assert_eq(dt.format(), "-0001-01-01T00:00:00Z")
+}
+
+///|
 test "DateTime::parse basic" {
   let dt = @src.DateTime::parse("1970-01-01T00:00:00Z")
   assert_eq(dt.to_unix_seconds(), 0L)
@@ -407,6 +423,18 @@ test "Show Date" {
 }
 
 ///|
+test "Show Date negative year" {
+  let d = @src.Date::new(-500, 6, 15)
+  inspect(d, content="-0500-06-15")
+}
+
+///|
+test "Show Date negative year -0001" {
+  let d = @src.Date::new(-1, 1, 1)
+  inspect(d, content="-0001-01-01")
+}
+
+///|
 test "Show Time" {
   let t = @src.Time::new(9, 5, 3, 0)
   inspect(t, content="09:05:03")
@@ -416,6 +444,14 @@ test "Show Time" {
 test "Show DateTime" {
   let dt = @src.DateTime::from_unix_seconds(1710506096L)
   inspect(dt, content="2024-03-15T12:34:56Z")
+}
+
+///|
+test "Show DateTime negative year" {
+  let d = @src.Date::new(-500, 6, 15)
+  let t = @src.Time::new(12, 0, 0, 0)
+  let dt = @src.DateTime::new(d, t)
+  inspect(dt, content="-0500-06-15T12:00:00Z")
 }
 
 ///|


### PR DESCRIPTION
## Summary

`pad4` treated negative years as a single signed integer, so year `-500` formatted as `-500` instead of the ISO 8601-style `-0500` (sign plus four-digit absolute value).

## Changes

- Add `pad4_year(year)` that prefixes `-` and applies `pad4` to the absolute value when `year < 0`; otherwise delegates to `pad4`.
- Use it in `DateTime::format` and `Show` for `Date`. `Show` for `DateTime` already uses `format()`, so it picks up the fix automatically.
- Add blackbox tests for years `-500` and `-1` (format and `Show`).
- Ignore `.cursor/` so local editor metadata does not block PR tooling.

Closes #5.