### PR TITLE
feat: accept fixed RFC 3339 offsets in DateTime::parse, normalize to UTC

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -60,8 +60,9 @@ test {
 
 ## Parsing
 
-Accepts RFC 3339 / ISO 8601. Only UTC offsets (`Z`, `+00:00`, `-00:00`) are
-accepted — others raise `TempoError`.
+Accepts RFC 3339 / ISO 8601. UTC markers (`Z`, `+00:00`, `-00:00`) and fixed
+numeric offsets are accepted. Parsed values are stored as UTC `DateTime`s; the
+original offset is not retained.
 
 ```moonbit nocheck
 ///|
@@ -74,13 +75,8 @@ test {
 ```moonbit nocheck
 ///|
 test {
-  let result = try {
-    @tempo.DateTime::parse("2026-03-28T14:31:43+09:00") |> ignore
-    "ok"
-  } catch {
-    @tempo.TempoError(_) => "error"
-  }
-  assert_eq(result, "error")
+  let dt = @tempo.DateTime::parse("2026-03-28T14:31:43+09:00")
+  inspect(dt.format(), content="2026-03-28T05:31:43Z")
 }
 ```
 

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -749,7 +749,18 @@ pub fn DateTime::parse(s : String) -> DateTime raise TempoError {
   if offset_minutes == 0 {
     base
   } else {
-    base.sub(Duration::minutes(offset_minutes.to_int64()))
+    let total_min = (hour * 60 + minute - offset_minutes).to_int64()
+    let day_delta = floor_div64(total_min, 1440L).to_int()
+    let minute_of_day = floor_mod64(total_min, 1440L).to_int()
+    {
+      date: date.add_days(day_delta),
+      time: Time::new(
+        minute_of_day / 60,
+        minute_of_day % 60,
+        second,
+        nanosecond,
+      ),
+    }
   }
 }
 

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -695,7 +695,7 @@ fn parse_frac_ns(view : StringView) -> (Int, StringView) raise TempoError {
 
 ///|
 /// Parse an RFC 3339 / ISO 8601 datetime string.
-/// Only UTC is accepted: 'Z', '+00:00', or '-00:00'.
+/// Fixed numeric offsets are accepted and normalized to UTC.
 pub fn DateTime::parse(s : String) -> DateTime raise TempoError {
   let v = s.view()
   let (year, v) = parse_digits(v, 4)
@@ -719,19 +719,21 @@ pub fn DateTime::parse(s : String) -> DateTime raise TempoError {
     ['.', .. rest] => parse_frac_ns(rest)
     _ => (0, v)
   }
-  // Timezone: Z or ±HH:MM (only UTC accepted)
-  let v = match v {
-    ['Z' | 'z', .. rest] => rest
+  // Timezone: Z or ±HH:MM.
+  let (v, offset_minutes) = match v {
+    ['Z' | 'z', .. rest] => (rest, 0)
     ['+' | '-' as sign, .. rest] => {
       let (tz_h, rest) = parse_digits(rest, 2)
       let rest = consume(rest, ':')
       let (tz_m, rest) = parse_digits(rest, 2)
-      if tz_h != 0 || tz_m != 0 {
+      if tz_h > 23 || tz_m > 59 {
         raise TempoError(
-          "non-UTC offset '\{sign}\{pad2(tz_h)}:\{pad2(tz_m)}' not supported",
+          "offset '\{sign}\{pad2(tz_h)}:\{pad2(tz_m)}' out of range",
         )
       }
-      rest
+      let minutes = tz_h * 60 + tz_m
+      let minutes = if sign == '-' { -minutes } else { minutes }
+      (rest, minutes)
     }
     [c, ..] => raise TempoError("expected timezone, got '\{c}'")
     [] => raise TempoError("unexpected end of input, expected timezone")
@@ -743,7 +745,12 @@ pub fn DateTime::parse(s : String) -> DateTime raise TempoError {
   }
   let date = Date::new(year, month, day)
   let time = Time::new(hour, minute, second, nanosecond)
-  { date, time }
+  let base = { date, time }
+  if offset_minutes == 0 {
+    base
+  } else {
+    base.sub(Duration::minutes(offset_minutes.to_int64()))
+  }
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -432,6 +432,25 @@ test "DateTime::parse offset normalization preserves fractional seconds" {
 }
 
 ///|
+test "DateTime::parse offset normalization future year overflow safe" {
+  let dt = @tempo.DateTime::parse("3000-01-01T00:30:00+01:00")
+  assert_eq(dt.format(), "2999-12-31T23:30:00Z")
+}
+
+///|
+test "DateTime::parse offset normalization past year overflow safe" {
+  let dt = @tempo.DateTime::parse("1000-01-01T05:00:00-06:00")
+  assert_eq(dt.format(), "1000-01-01T11:00:00Z")
+}
+
+///|
+test "DateTime::parse offset normalization matches Z equivalent" {
+  let offset = @tempo.DateTime::parse("3000-06-15T12:00:00+05:00")
+  let utc = @tempo.DateTime::parse("3000-06-15T07:00:00Z")
+  assert_eq(offset, utc)
+}
+
+///|
 test "DateTime::parse rejects out-of-range offset" {
   assert_true(
     (try? @tempo.DateTime::parse("2024-03-15T12:34:56+24:00")) is Err(_),

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -391,18 +391,53 @@ test "DateTime::parse fractional seconds all nines overflow safe" {
 test "DateTime::parse +00:00 offset" {
   let dt = @tempo.DateTime::parse("2024-03-15T12:34:56+00:00")
   assert_eq(dt.to_unix_seconds(), 1710506096L)
+  assert_eq(dt.format(), "2024-03-15T12:34:56Z")
 }
 
 ///|
 test "DateTime::parse -00:00 offset" {
   let dt = @tempo.DateTime::parse("2024-03-15T12:34:56-00:00")
   assert_eq(dt.to_unix_seconds(), 1710506096L)
+  assert_eq(dt.format(), "2024-03-15T12:34:56Z")
 }
 
 ///|
-test "DateTime::parse non-UTC offset rejected" {
+test "DateTime::parse positive offset normalized to UTC" {
+  let dt = @tempo.DateTime::parse("2024-07-21T17:11:00+09:00")
+  assert_eq(dt.format(), "2024-07-21T08:11:00Z")
+}
+
+///|
+test "DateTime::parse negative offset normalized to UTC" {
+  let dt = @tempo.DateTime::parse("2024-07-21T17:11:00-04:00")
+  assert_eq(dt.format(), "2024-07-21T21:11:00Z")
+}
+
+///|
+test "DateTime::parse offset normalization crosses date forward" {
+  let dt = @tempo.DateTime::parse("2024-07-21T23:30:00-04:00")
+  assert_eq(dt.format(), "2024-07-22T03:30:00Z")
+}
+
+///|
+test "DateTime::parse offset normalization crosses date backward" {
+  let dt = @tempo.DateTime::parse("2024-07-21T02:30:00+09:00")
+  assert_eq(dt.format(), "2024-07-20T17:30:00Z")
+}
+
+///|
+test "DateTime::parse offset normalization preserves fractional seconds" {
+  let dt = @tempo.DateTime::parse("2024-03-28T14:31:43.125-04:00")
+  assert_eq(dt.format(), "2024-03-28T18:31:43.125Z")
+}
+
+///|
+test "DateTime::parse rejects out-of-range offset" {
   assert_true(
-    (try? @tempo.DateTime::parse("2024-03-15T12:34:56+05:30")) is Err(_),
+    (try? @tempo.DateTime::parse("2024-03-15T12:34:56+24:00")) is Err(_),
+  )
+  assert_true(
+    (try? @tempo.DateTime::parse("2024-03-15T12:34:56+05:60")) is Err(_),
   )
 }
 


### PR DESCRIPTION
## What

`DateTime::parse` now accepts fixed RFC 3339 numeric offsets (e.g. `2024-07-21T17:11:00-04:00`, `+09:00`) and **normalizes them to UTC**. Previously any non-zero offset raised `TempoError` — so the library couldn't ingest the most common real-world timestamp shape despite advertising "RFC 3339 parsing." The parser already extracted the offset; it now applies it instead of rejecting it.

## How

- Parse the offset sign/hours/minutes, validate range (raise `TempoError` on out-of-range), and normalize via `base.sub(Duration::minutes(signed_offset))`. UTC = local − offset, so `+09:00` subtracts 9h and `-04:00` adds 4h. Date-boundary crossing falls out of the existing `DateTime` arithmetic.
- UTC-only storage; the original offset is **not** retained. A `FixedOffsetDateTime` that keeps the display offset is the separate bead `tempo-1ms.2`.

## Tests

Both offset signs, date-boundary crossings (forward + backward), fractional-second preservation, out-of-range rejection, and existing `Z` / `+00:00` / `-00:00` forms still round-trip.

## Verify

- `moon fmt --check` clean
- `moon info` — `.mbti` unchanged (no public API change)
- `moon test` green on **wasm-gc / js / native** (142 tests each)

Closes `tempo-1ms.1`.
