### PR TITLE
Add Date month/year arithmetic for tempo-0fu.1 and tempo-0fu.2

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -19,6 +19,8 @@ pub struct Date {
   day : Int
 } derive(Compare, Eq)
 pub fn Date::add_days(Self, Int) -> Self
+pub fn Date::add_months(Self, Int) -> Self
+pub fn Date::add_years(Self, Int) -> Self
 pub fn Date::day_of_week(Self) -> Int
 pub fn Date::day_of_year(Self) -> Int
 pub fn Date::days_until(Self, Self) -> Int

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -129,6 +129,37 @@ pub fn Date::new(year : Int, month : Int, day : Int) -> Date raise TempoError {
 // ─── Date arithmetic ──────────────────────────────────────────────────────────
 
 ///|
+fn shift_year_month(year : Int, month : Int, months : Int) -> (Int, Int) {
+  let total = year.to_int64() * 12L + (month - 1).to_int64() + months.to_int64()
+  let new_year = floor_div64(total, 12L).to_int()
+  let new_month = floor_mod64(total, 12L).to_int() + 1
+  (new_year, new_month)
+}
+
+///|
+/// Add a signed number of calendar months to this date.
+///
+/// If the original day does not exist in the target month, the result is
+/// clamped to that month's last day. Clamping is non-sticky: 2024-02-28 plus
+/// one month is 2024-03-28, not 2024-03-31.
+pub fn Date::add_months(self : Date, months : Int) -> Date {
+  let (year, month) = shift_year_month(self.year, self.month, months)
+  let max_day = days_in_month(year, month)
+  let day = if self.day > max_day { max_day } else { self.day }
+  { year, month, day }
+}
+
+///|
+/// Add a signed number of calendar years to this date.
+///
+/// If the original day does not exist in the target year/month, the result is
+/// clamped to that month's last day, so leap day moves to February 28 in
+/// non-leap target years.
+pub fn Date::add_years(self : Date, years : Int) -> Date {
+  self.add_months(years * 12)
+}
+
+///|
 /// Add a signed number of calendar days to this date (proleptic Gregorian).
 pub fn Date::add_days(self : Date, days : Int) -> Date {
   let base = days_from_civil(self.year, self.month, self.day)

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -129,11 +129,19 @@ pub fn Date::new(year : Int, month : Int, day : Int) -> Date raise TempoError {
 // ─── Date arithmetic ──────────────────────────────────────────────────────────
 
 ///|
-fn shift_year_month(year : Int, month : Int, months : Int) -> (Int, Int) {
-  let total = year.to_int64() * 12L + (month - 1).to_int64() + months.to_int64()
+fn shift_year_month(year : Int, month : Int, months : Int64) -> (Int, Int) {
+  let total = year.to_int64() * 12L + (month - 1).to_int64() + months
   let new_year = floor_div64(total, 12L).to_int()
   let new_month = floor_mod64(total, 12L).to_int() + 1
   (new_year, new_month)
+}
+
+///|
+fn Date::add_months64(self : Date, months : Int64) -> Date {
+  let (year, month) = shift_year_month(self.year, self.month, months)
+  let max_day = days_in_month(year, month)
+  let day = if self.day > max_day { max_day } else { self.day }
+  { year, month, day }
 }
 
 ///|
@@ -143,10 +151,7 @@ fn shift_year_month(year : Int, month : Int, months : Int) -> (Int, Int) {
 /// clamped to that month's last day. Clamping is non-sticky: 2024-02-28 plus
 /// one month is 2024-03-28, not 2024-03-31.
 pub fn Date::add_months(self : Date, months : Int) -> Date {
-  let (year, month) = shift_year_month(self.year, self.month, months)
-  let max_day = days_in_month(year, month)
-  let day = if self.day > max_day { max_day } else { self.day }
-  { year, month, day }
+  self.add_months64(months.to_int64())
 }
 
 ///|
@@ -156,7 +161,7 @@ pub fn Date::add_months(self : Date, months : Int) -> Date {
 /// clamped to that month's last day, so leap day moves to February 28 in
 /// non-leap target years.
 pub fn Date::add_years(self : Date, years : Int) -> Date {
-  self.add_months(years * 12)
+  self.add_months64(years.to_int64() * 12L)
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -149,6 +149,14 @@ test "Date::add_years handles negative and normal dates" {
 }
 
 ///|
+test "Date::add_years avoids Int month overflow" {
+  assert_eq(
+    @tempo.Date::new(2024, 1, 1).add_years(178_956_971),
+    @tempo.Date::new(178958995, 1, 1),
+  )
+}
+
+///|
 test "Date::day_of_week ISO" {
   // 1970-01-01 Thursday; 2024-01-01 Monday; 2024-03-15 Friday
   assert_eq(@tempo.Date::new(1970, 1, 1).day_of_week(), 4)

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -69,6 +69,82 @@ test "Date::add_days leap day" {
 }
 
 ///|
+test "Date::add_months clamps end of month" {
+  assert_eq(
+    @tempo.Date::new(2023, 1, 31).add_months(1),
+    @tempo.Date::new(2023, 2, 28),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 1, 31).add_months(1),
+    @tempo.Date::new(2024, 2, 29),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 3, 31).add_months(1),
+    @tempo.Date::new(2024, 4, 30),
+  )
+}
+
+///|
+test "Date::add_months preserves valid target day" {
+  assert_eq(
+    @tempo.Date::new(2024, 1, 31).add_months(2),
+    @tempo.Date::new(2024, 3, 31),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 2, 28).add_months(1),
+    @tempo.Date::new(2024, 3, 28),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 1, 31).add_months(12),
+    @tempo.Date::new(2025, 1, 31),
+  )
+}
+
+///|
+test "Date::add_months wraps years and handles negatives" {
+  assert_eq(
+    @tempo.Date::new(2024, 12, 10).add_months(1),
+    @tempo.Date::new(2025, 1, 10),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 3, 15).add_months(-1),
+    @tempo.Date::new(2024, 2, 15),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 1, 10).add_months(-1),
+    @tempo.Date::new(2023, 12, 10),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 1, 31).add_months(25),
+    @tempo.Date::new(2026, 2, 28),
+  )
+}
+
+///|
+test "Date::add_years clamps leap day" {
+  assert_eq(
+    @tempo.Date::new(2024, 2, 29).add_years(1),
+    @tempo.Date::new(2025, 2, 28),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 2, 29).add_years(4),
+    @tempo.Date::new(2028, 2, 29),
+  )
+}
+
+///|
+test "Date::add_years handles negative and normal dates" {
+  assert_eq(
+    @tempo.Date::new(2024, 2, 29).add_years(-1),
+    @tempo.Date::new(2023, 2, 28),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 3, 15).add_years(1),
+    @tempo.Date::new(2025, 3, 15),
+  )
+}
+
+///|
 test "Date::day_of_week ISO" {
   // 1970-01-01 Thursday; 2024-01-01 Monday; 2024-03-15 Friday
   assert_eq(@tempo.Date::new(1970, 1, 1).day_of_week(), 4)

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -111,6 +111,10 @@ test "Date::add_months wraps years and handles negatives" {
     @tempo.Date::new(2024, 2, 15),
   )
   assert_eq(
+    @tempo.Date::new(2024, 3, 31).add_months(-1),
+    @tempo.Date::new(2024, 2, 29),
+  )
+  assert_eq(
     @tempo.Date::new(2024, 1, 10).add_months(-1),
     @tempo.Date::new(2023, 12, 10),
   )


### PR DESCRIPTION
## Summary
- Adds Date::add_months with end-of-month clamping and non-sticky behavior.
- Adds Date::add_years via shared month arithmetic with leap-day clamping.
- Updates blackbox coverage and generated interface.

Closes tempo-0fu.1.
Closes tempo-0fu.2.

## Verification
- moon fmt --check
- moon test --target wasm-gc
- moon test --target js
- moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: 20e3abb7e3b566402047d952382c08a76926025e
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: 20e3abb7e3b566402047d952382c08a76926025e
  - output tail:
```text
Total tests: 155, passed: 155, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: 20e3abb7e3b566402047d952382c08a76926025e
  - output tail:
```text
Total tests: 155, passed: 155, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: 20e3abb7e3b566402047d952382c08a76926025e
  - output tail:
```text
Total tests: 155, passed: 155, failed: 0.
```