### PR TITLE
Add month/year boundary adjusters for tempo-0fu.6

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -24,9 +24,13 @@ pub fn Date::add_years(Self, Int) -> Self
 pub fn Date::day_of_week(Self) -> Int
 pub fn Date::day_of_year(Self) -> Int
 pub fn Date::days_until(Self, Self) -> Int
+pub fn Date::end_of_month(Self) -> Self
+pub fn Date::end_of_year(Self) -> Self
 pub fn Date::format(Self) -> String
 pub fn Date::new(Int, Int, Int) -> Self raise TempoError
 pub fn Date::parse(String) -> Self raise TempoError
+pub fn Date::start_of_month(Self) -> Self
+pub fn Date::start_of_year(Self) -> Self
 pub impl Show for Date
 
 pub struct DateTime {
@@ -35,6 +39,8 @@ pub struct DateTime {
 } derive(Compare, Eq)
 pub fn DateTime::add(Self, Duration) -> Self
 pub fn DateTime::diff(Self, Self) -> Duration
+pub fn DateTime::end_of_month(Self) -> Self
+pub fn DateTime::end_of_year(Self) -> Self
 pub fn DateTime::epoch() -> Self
 pub fn DateTime::format(Self) -> String
 pub fn DateTime::from_unix_nanos(Int64) -> Self
@@ -42,6 +48,8 @@ pub fn DateTime::from_unix_seconds(Int64) -> Self
 pub fn DateTime::new(Date, Time) -> Self
 pub fn DateTime::now() -> Self
 pub fn DateTime::parse(String) -> Self raise TempoError
+pub fn DateTime::start_of_month(Self) -> Self
+pub fn DateTime::start_of_year(Self) -> Self
 pub fn DateTime::sub(Self, Duration) -> Self
 pub fn DateTime::to_unix_nanos(Self) -> Int64
 pub fn DateTime::to_unix_seconds(Self) -> Int64

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -165,6 +165,30 @@ pub fn Date::add_years(self : Date, years : Int) -> Date {
 }
 
 ///|
+/// Return the first day of this date's calendar month.
+pub fn Date::start_of_month(self : Date) -> Date {
+  { ..self, day: 1 }
+}
+
+///|
+/// Return the last day of this date's calendar month.
+pub fn Date::end_of_month(self : Date) -> Date {
+  { ..self, day: days_in_month(self.year, self.month) }
+}
+
+///|
+/// Return the first day of this date's calendar year.
+pub fn Date::start_of_year(self : Date) -> Date {
+  { ..self, month: 1, day: 1 }
+}
+
+///|
+/// Return the last day of this date's calendar year.
+pub fn Date::end_of_year(self : Date) -> Date {
+  { ..self, month: 12, day: 31 }
+}
+
+///|
 /// Add a signed number of calendar days to this date (proleptic Gregorian).
 pub fn Date::add_days(self : Date, days : Int) -> Date {
   let base = days_from_civil(self.year, self.month, self.day)
@@ -264,6 +288,38 @@ pub fn DateTime::epoch() -> DateTime {
     date: { year: 1970, month: 1, day: 1 },
     time: { hour: 0, minute: 0, second: 0, nanosecond: 0 },
   }
+}
+
+///|
+/// Return this DateTime at the start of its calendar month.
+/// Preserves the time-of-day; compose with a future `start_of_day` if midnight
+/// is desired.
+pub fn DateTime::start_of_month(self : DateTime) -> DateTime {
+  DateTime::new(self.date.start_of_month(), self.time)
+}
+
+///|
+/// Return this DateTime at the end of its calendar month.
+/// Preserves the time-of-day; compose with a future `start_of_day` if midnight
+/// is desired.
+pub fn DateTime::end_of_month(self : DateTime) -> DateTime {
+  DateTime::new(self.date.end_of_month(), self.time)
+}
+
+///|
+/// Return this DateTime at the start of its calendar year.
+/// Preserves the time-of-day; compose with a future `start_of_day` if midnight
+/// is desired.
+pub fn DateTime::start_of_year(self : DateTime) -> DateTime {
+  DateTime::new(self.date.start_of_year(), self.time)
+}
+
+///|
+/// Return this DateTime at the end of its calendar year.
+/// Preserves the time-of-day; compose with a future `start_of_day` if midnight
+/// is desired.
+pub fn DateTime::end_of_year(self : DateTime) -> DateTime {
+  DateTime::new(self.date.end_of_year(), self.time)
 }
 
 // ─── Unix timestamp conversion ────────────────────────────────────────────────

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -292,32 +292,32 @@ pub fn DateTime::epoch() -> DateTime {
 
 ///|
 /// Return this DateTime at the start of its calendar month.
-/// Preserves the time-of-day; compose with a future `start_of_day` if midnight
-/// is desired.
+/// Preserves the time-of-day; rebuild with `DateTime::new` and a zero `Time` if
+/// midnight is desired.
 pub fn DateTime::start_of_month(self : DateTime) -> DateTime {
   DateTime::new(self.date.start_of_month(), self.time)
 }
 
 ///|
 /// Return this DateTime at the end of its calendar month.
-/// Preserves the time-of-day; compose with a future `start_of_day` if midnight
-/// is desired.
+/// Preserves the time-of-day; rebuild with `DateTime::new` and a zero `Time` if
+/// midnight is desired.
 pub fn DateTime::end_of_month(self : DateTime) -> DateTime {
   DateTime::new(self.date.end_of_month(), self.time)
 }
 
 ///|
 /// Return this DateTime at the start of its calendar year.
-/// Preserves the time-of-day; compose with a future `start_of_day` if midnight
-/// is desired.
+/// Preserves the time-of-day; rebuild with `DateTime::new` and a zero `Time` if
+/// midnight is desired.
 pub fn DateTime::start_of_year(self : DateTime) -> DateTime {
   DateTime::new(self.date.start_of_year(), self.time)
 }
 
 ///|
 /// Return this DateTime at the end of its calendar year.
-/// Preserves the time-of-day; compose with a future `start_of_day` if midnight
-/// is desired.
+/// Preserves the time-of-day; rebuild with `DateTime::new` and a zero `Time` if
+/// midnight is desired.
 pub fn DateTime::end_of_year(self : DateTime) -> DateTime {
   DateTime::new(self.date.end_of_year(), self.time)
 }

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -157,6 +157,51 @@ test "Date::add_years avoids Int month overflow" {
 }
 
 ///|
+test "Date boundary adjusters for month ends" {
+  assert_eq(
+    @tempo.Date::new(2024, 2, 10).end_of_month(),
+    @tempo.Date::new(2024, 2, 29),
+  )
+  assert_eq(
+    @tempo.Date::new(2023, 2, 10).end_of_month(),
+    @tempo.Date::new(2023, 2, 28),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 4, 15).end_of_month(),
+    @tempo.Date::new(2024, 4, 30),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 7, 9).end_of_month(),
+    @tempo.Date::new(2024, 7, 31),
+  )
+}
+
+///|
+test "Date boundary adjusters for month and year starts" {
+  assert_eq(
+    @tempo.Date::new(2024, 4, 15).start_of_month(),
+    @tempo.Date::new(2024, 4, 1),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 7, 9).start_of_year(),
+    @tempo.Date::new(2024, 1, 1),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 7, 9).end_of_year(),
+    @tempo.Date::new(2024, 12, 31),
+  )
+}
+
+///|
+test "DateTime boundary adjusters preserve time of day" {
+  let dt = @tempo.DateTime::parse("2024-03-15T14:30:00Z")
+  assert_eq(dt.start_of_month().format(), "2024-03-01T14:30:00Z")
+  assert_eq(dt.end_of_month().format(), "2024-03-31T14:30:00Z")
+  assert_eq(dt.start_of_year().format(), "2024-01-01T14:30:00Z")
+  assert_eq(dt.end_of_year().format(), "2024-12-31T14:30:00Z")
+}
+
+///|
 test "Date::day_of_week ISO" {
   // 1970-01-01 Thursday; 2024-01-01 Monday; 2024-03-15 Friday
   assert_eq(@tempo.Date::new(1970, 1, 1).day_of_week(), 4)


### PR DESCRIPTION
Closes bead tempo-0fu.6.

Adds infallible Date start/end-of-month and start/end-of-year adjusters, plus DateTime wrappers that preserve the time-of-day by rebuilding with DateTime::new(self.date.<boundary>(), self.time).

Verification:
- moon info && moon fmt
- moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: d9dc52cc9214cf74afa10192389fc506b2f956f7
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: d9dc52cc9214cf74afa10192389fc506b2f956f7
  - output tail:
```text
Total tests: 159, passed: 159, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: d9dc52cc9214cf74afa10192389fc506b2f956f7
  - output tail:
```text
Total tests: 159, passed: 159, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: d9dc52cc9214cf74afa10192389fc506b2f956f7
  - output tail:
```text
Total tests: 159, passed: 159, failed: 0.
```