### PR TITLE
Add decomposition accessors and with updaters

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -31,6 +31,9 @@ pub fn Date::new(Int, Int, Int) -> Self raise TempoError
 pub fn Date::parse(String) -> Self raise TempoError
 pub fn Date::start_of_month(Self) -> Self
 pub fn Date::start_of_year(Self) -> Self
+pub fn Date::with_day(Self, Int) -> Self raise TempoError
+pub fn Date::with_month(Self, Int) -> Self raise TempoError
+pub fn Date::with_year(Self, Int) -> Self raise TempoError
 pub impl Show for Date
 
 pub struct DateTime {
@@ -51,8 +54,19 @@ pub fn DateTime::parse(String) -> Self raise TempoError
 pub fn DateTime::start_of_month(Self) -> Self
 pub fn DateTime::start_of_year(Self) -> Self
 pub fn DateTime::sub(Self, Duration) -> Self
+pub fn DateTime::to_date(Self) -> Date
+pub fn DateTime::to_time(Self) -> Time
 pub fn DateTime::to_unix_nanos(Self) -> Int64
 pub fn DateTime::to_unix_seconds(Self) -> Int64
+pub fn DateTime::with_date(Self, Date) -> Self
+pub fn DateTime::with_day(Self, Int) -> Self raise TempoError
+pub fn DateTime::with_hour(Self, Int) -> Self raise TempoError
+pub fn DateTime::with_minute(Self, Int) -> Self raise TempoError
+pub fn DateTime::with_month(Self, Int) -> Self raise TempoError
+pub fn DateTime::with_nanosecond(Self, Int) -> Self raise TempoError
+pub fn DateTime::with_second(Self, Int) -> Self raise TempoError
+pub fn DateTime::with_time(Self, Time) -> Self
+pub fn DateTime::with_year(Self, Int) -> Self raise TempoError
 pub impl Show for DateTime
 
 pub struct Duration {
@@ -90,6 +104,10 @@ pub struct Time {
 pub fn Time::format(Self) -> String
 pub fn Time::new(Int, Int, Int, Int) -> Self raise TempoError
 pub fn Time::parse(String) -> Self raise TempoError
+pub fn Time::with_hour(Self, Int) -> Self raise TempoError
+pub fn Time::with_minute(Self, Int) -> Self raise TempoError
+pub fn Time::with_nanosecond(Self, Int) -> Self raise TempoError
+pub fn Time::with_second(Self, Int) -> Self raise TempoError
 pub impl Show for Time
 
 // Type aliases

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -165,6 +165,30 @@ pub fn Date::add_years(self : Date, years : Int) -> Date {
 }
 
 ///|
+/// Return a copy of this date with `year` replaced, validating the result.
+pub fn Date::with_year(self : Date, year : Int) -> Date raise TempoError {
+  Date::new(year, self.month, self.day)
+}
+
+///|
+/// Return a copy of this date with `month` replaced, validating the result.
+///
+/// This does not clamp. Chaining with `with_day` can raise on an intermediate
+/// invalid date before a later update would make it valid.
+pub fn Date::with_month(self : Date, month : Int) -> Date raise TempoError {
+  Date::new(self.year, month, self.day)
+}
+
+///|
+/// Return a copy of this date with `day` replaced, validating the result.
+///
+/// This does not clamp. Chaining with `with_month` can raise on an intermediate
+/// invalid date before a later update would make it valid.
+pub fn Date::with_day(self : Date, day : Int) -> Date raise TempoError {
+  Date::new(self.year, self.month, day)
+}
+
+///|
 /// Return the first day of this date's calendar month.
 pub fn Date::start_of_month(self : Date) -> Date {
   { ..self, day: 1 }
@@ -274,11 +298,125 @@ pub fn Time::new(
 }
 
 ///|
+/// Return a copy of this time with `hour` replaced, validating the result.
+pub fn Time::with_hour(self : Time, hour : Int) -> Time raise TempoError {
+  Time::new(hour, self.minute, self.second, self.nanosecond)
+}
+
+///|
+/// Return a copy of this time with `minute` replaced, validating the result.
+pub fn Time::with_minute(self : Time, minute : Int) -> Time raise TempoError {
+  Time::new(self.hour, minute, self.second, self.nanosecond)
+}
+
+///|
+/// Return a copy of this time with `second` replaced, validating the result.
+pub fn Time::with_second(self : Time, second : Int) -> Time raise TempoError {
+  Time::new(self.hour, self.minute, second, self.nanosecond)
+}
+
+///|
+/// Return a copy of this time with `nanosecond` replaced, validating the result.
+pub fn Time::with_nanosecond(
+  self : Time,
+  nanosecond : Int,
+) -> Time raise TempoError {
+  Time::new(self.hour, self.minute, self.second, nanosecond)
+}
+
+///|
 /// Create a `DateTime` from a validated `Date` and `Time`.
 /// Both arguments should be constructed via `Date::new` / `Time::new` (which
 /// validate). This constructor performs no additional checks.
 pub fn DateTime::new(date : Date, time : Time) -> DateTime {
   { date, time }
+}
+
+///|
+/// Return the date component of this `DateTime`.
+pub fn DateTime::to_date(self : DateTime) -> Date {
+  self.date
+}
+
+///|
+/// Return the time component of this `DateTime`.
+pub fn DateTime::to_time(self : DateTime) -> Time {
+  self.time
+}
+
+///|
+/// Return a copy of this `DateTime` with `date` replaced.
+pub fn DateTime::with_date(self : DateTime, date : Date) -> DateTime {
+  { ..self, date, }
+}
+
+///|
+/// Return a copy of this `DateTime` with `time` replaced.
+pub fn DateTime::with_time(self : DateTime, time : Time) -> DateTime {
+  { ..self, time, }
+}
+
+///|
+/// Return a copy of this `DateTime` with its date year replaced.
+pub fn DateTime::with_year(
+  self : DateTime,
+  year : Int,
+) -> DateTime raise TempoError {
+  { ..self, date: self.date.with_year(year) }
+}
+
+///|
+/// Return a copy of this `DateTime` with its date month replaced.
+pub fn DateTime::with_month(
+  self : DateTime,
+  month : Int,
+) -> DateTime raise TempoError {
+  { ..self, date: self.date.with_month(month) }
+}
+
+///|
+/// Return a copy of this `DateTime` with its date day replaced.
+pub fn DateTime::with_day(
+  self : DateTime,
+  day : Int,
+) -> DateTime raise TempoError {
+  { ..self, date: self.date.with_day(day) }
+}
+
+///|
+/// Return a copy of this `DateTime` with its time hour replaced.
+pub fn DateTime::with_hour(
+  self : DateTime,
+  hour : Int,
+) -> DateTime raise TempoError {
+  { ..self, time: self.time.with_hour(hour) }
+}
+
+///|
+/// Return a copy of this `DateTime` with its time minute replaced.
+pub fn DateTime::with_minute(
+  self : DateTime,
+  minute : Int,
+) -> DateTime raise TempoError {
+  { ..self, time: self.time.with_minute(minute) }
+}
+
+///|
+/// Return a copy of this `DateTime` with its time second replaced.
+pub fn DateTime::with_second(
+  self : DateTime,
+  second : Int,
+) -> DateTime raise TempoError {
+  { ..self, time: self.time.with_second(second) }
+}
+
+///|
+/// Return a copy of this `DateTime` with its time nanosecond replaced.
+pub fn DateTime::with_nanosecond(
+  self : DateTime,
+  nanosecond : Int,
+) -> DateTime raise TempoError {
+  { ..self, time: self.time.with_nanosecond(nanosecond) }
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -157,6 +157,21 @@ test "Date::add_years avoids Int month overflow" {
 }
 
 ///|
+test "Date::with field updaters" {
+  let d = @tempo.Date::new(2024, 3, 15)
+  assert_eq(d.with_day(1), @tempo.Date::new(2024, 3, 1))
+  assert_eq(d.with_month(12), @tempo.Date::new(2024, 12, 15))
+  assert_eq(d.with_year(2025), @tempo.Date::new(2025, 3, 15))
+}
+
+///|
+test "Date::with field updaters reject invalid dates" {
+  assert_true((try? @tempo.Date::new(2024, 2, 29).with_year(2023)) is Err(_))
+  assert_true((try? @tempo.Date::new(2024, 1, 31).with_month(2)) is Err(_))
+  assert_true((try? @tempo.Date::new(2024, 3, 15).with_day(32)) is Err(_))
+}
+
+///|
 test "Date boundary adjusters for month ends" {
   assert_eq(
     @tempo.Date::new(2024, 2, 10).end_of_month(),
@@ -199,6 +214,41 @@ test "DateTime boundary adjusters preserve time of day" {
   assert_eq(dt.end_of_month().format(), "2024-03-31T14:30:00Z")
   assert_eq(dt.start_of_year().format(), "2024-01-01T14:30:00Z")
   assert_eq(dt.end_of_year().format(), "2024-12-31T14:30:00Z")
+}
+
+///|
+test "DateTime accessors and component updaters" {
+  let date = @tempo.Date::new(2024, 3, 15)
+  let time = @tempo.Time::new(12, 34, 56, 789)
+  let dt = @tempo.DateTime::new(date, time)
+  assert_eq(dt.to_date(), date)
+  assert_eq(dt.to_time(), time)
+  assert_eq(
+    dt.with_date(@tempo.Date::new(2025, 1, 2)),
+    @tempo.DateTime::new(@tempo.Date::new(2025, 1, 2), time),
+  )
+  assert_eq(
+    dt.with_time(@tempo.Time::new(1, 2, 3, 4)),
+    @tempo.DateTime::new(date, @tempo.Time::new(1, 2, 3, 4)),
+  )
+}
+
+///|
+test "DateTime scalar updaters delegate to date and time" {
+  let dt = @tempo.DateTime::parse("2024-03-15T12:34:56.000000789Z")
+  assert_eq(dt.with_day(1).format(), "2024-03-01T12:34:56.000000789Z")
+  assert_eq(dt.with_hour(1).format(), "2024-03-15T01:34:56.000000789Z")
+  assert_eq(dt.with_month(12).date, @tempo.Date::new(2024, 12, 15))
+  assert_eq(dt.with_minute(2).time, @tempo.Time::new(12, 2, 56, 789))
+  assert_eq(dt.with_second(3).time, @tempo.Time::new(12, 34, 3, 789))
+  assert_eq(dt.with_nanosecond(4).time, @tempo.Time::new(12, 34, 56, 4))
+  assert_eq(dt.with_year(2025).date, @tempo.Date::new(2025, 3, 15))
+}
+
+///|
+test "DateTime scalar updaters reject invalid delegated fields" {
+  let dt = @tempo.DateTime::parse("2024-02-15T12:34:56Z")
+  assert_true((try? dt.with_day(31)) is Err(_))
 }
 
 ///|
@@ -265,6 +315,24 @@ test "Time::new valid" {
   assert_eq(t.minute, 59)
   assert_eq(t.second, 59)
   assert_eq(t.nanosecond, 999_999_999)
+}
+
+///|
+test "Time::with field updaters" {
+  let t = @tempo.Time::new(12, 34, 56, 789)
+  assert_eq(t.with_hour(1), @tempo.Time::new(1, 34, 56, 789))
+  assert_eq(t.with_minute(2), @tempo.Time::new(12, 2, 56, 789))
+  assert_eq(t.with_second(3), @tempo.Time::new(12, 34, 3, 789))
+  assert_eq(t.with_nanosecond(4), @tempo.Time::new(12, 34, 56, 4))
+}
+
+///|
+test "Time::with field updaters reject invalid times" {
+  assert_true((try? @tempo.Time::new(12, 34, 56, 789).with_hour(24)) is Err(_))
+  assert_true(
+    (try? @tempo.Time::new(12, 34, 56, 789).with_nanosecond(1_000_000_000))
+    is Err(_),
+  )
 }
 
 ///|


### PR DESCRIPTION
Closes tempo-5nc.6, tempo-0fu.3, tempo-0fu.4, tempo-0fu.5.\n\nAdds DateTime to_date/to_time accessors plus immutable with_* field updaters for Date, Time, and DateTime. Fallible scalar updates route through Date::new/Time::new so invalid intermediate dates and out-of-range time fields raise TempoError without clamping; DateTime with_date/with_time are pure component replacements.\n\nVerification:\n- TDD red: configured verify failed on missing public methods\n- moon info && moon fmt\n- .mbti adds exactly 18 requested public functions\n- moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: 6859f5d752152e1cc72f5fe3dbe14581e71bd648
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: 6859f5d752152e1cc72f5fe3dbe14581e71bd648
  - output tail:
```text
Total tests: 166, passed: 166, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: 6859f5d752152e1cc72f5fe3dbe14581e71bd648
  - output tail:
```text
Total tests: 166, passed: 166, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: 6859f5d752152e1cc72f5fe3dbe14581e71bd648
  - output tail:
```text
Total tests: 166, passed: 166, failed: 0.
```