### PR TITLE
Add Duration sign and scalar arithmetic helpers

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -74,6 +74,7 @@ pub impl Show for DateTime
 pub struct Duration {
   nanoseconds : Int64
 } derive(Compare, Eq)
+pub fn Duration::abs(Self) -> Self
 pub fn Duration::as_days(Self) -> Int64
 pub fn Duration::as_hours(Self) -> Int64
 pub fn Duration::as_microseconds(Self) -> Int64
@@ -82,15 +83,20 @@ pub fn Duration::as_minutes(Self) -> Int64
 pub fn Duration::as_nanoseconds(Self) -> Int64
 pub fn Duration::as_seconds(Self) -> Int64
 pub fn Duration::as_weeks(Self) -> Int64
+pub fn Duration::checked_multiply(Self, Int64) -> Self?
 pub fn Duration::days(Int64) -> Self
+pub fn Duration::divide(Self, Int64) -> Self raise TempoError
 pub fn Duration::hours(Int64) -> Self
 pub fn Duration::is_negative(Self) -> Bool
+pub fn Duration::is_positive(Self) -> Bool
 pub fn Duration::is_zero(Self) -> Bool
 pub fn Duration::microseconds(Int64) -> Self
 pub fn Duration::milliseconds(Int64) -> Self
 pub fn Duration::minutes(Int64) -> Self
+pub fn Duration::multiply(Self, Int64) -> Self
 pub fn Duration::nanoseconds(Int64) -> Self
 pub fn Duration::seconds(Int64) -> Self
+pub fn Duration::signum(Self) -> Int
 pub fn Duration::weeks(Int64) -> Self
 pub impl Add for Duration
 pub impl Neg for Duration

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -769,6 +769,12 @@ let ns_per_min : Int64 = 60_000_000_000L
 let ns_per_hour : Int64 = 3_600_000_000_000L
 
 ///|
+let int64_min_value : Int64 = -9_223_372_036_854_775_808L
+
+///|
+let int64_max_value : Int64 = 9_223_372_036_854_775_807L
+
+///|
 /// Create a Duration from a number of nanoseconds.
 pub fn Duration::nanoseconds(ns : Int64) -> Duration {
   { nanoseconds: ns }
@@ -877,7 +883,80 @@ pub fn Duration::is_negative(self : Duration) -> Bool {
   self.nanoseconds < 0L
 }
 
+///|
+/// Absolute value of this duration.
+///
+/// `Int64::min_value` cannot be negated as an `Int64`, so that edge saturates
+/// to `Int64::max_value` instead of raising or wrapping.
+pub fn Duration::abs(self : Duration) -> Duration {
+  if self.nanoseconds == int64_min_value {
+    { nanoseconds: int64_max_value }
+  } else if self.nanoseconds < 0L {
+    { nanoseconds: -self.nanoseconds }
+  } else {
+    self
+  }
+}
+
+///|
+/// `true` when this duration is greater than zero.
+pub fn Duration::is_positive(self : Duration) -> Bool {
+  self.nanoseconds > 0L
+}
+
+///|
+/// Sign of this duration: `-1` for negative, `0` for zero, `1` for positive.
+pub fn Duration::signum(self : Duration) -> Int {
+  if self.nanoseconds < 0L {
+    -1
+  } else if self.nanoseconds > 0L {
+    1
+  } else {
+    0
+  }
+}
+
 // ─── Duration arithmetic ──────────────────────────────────────────────────────
+
+///|
+/// Multiply this duration by an `Int64` scalar.
+///
+/// This wraps on `Int64` overflow. Use `checked_multiply` when overflow should
+/// return `None`.
+pub fn Duration::multiply(self : Duration, n : Int64) -> Duration {
+  { nanoseconds: self.nanoseconds * n }
+}
+
+///|
+/// Multiply this duration by an `Int64` scalar, returning `None` on overflow.
+pub fn Duration::checked_multiply(self : Duration, n : Int64) -> Duration? {
+  if n == 0L {
+    Some({ nanoseconds: 0L })
+  } else {
+    let product = self.nanoseconds * n
+    if product == int64_min_value && n == -1L {
+      None
+    } else if product / n == self.nanoseconds {
+      Some({ nanoseconds: product })
+    } else {
+      None
+    }
+  }
+}
+
+///|
+/// Divide this duration by an `Int64` scalar, truncating toward zero.
+///
+/// Division by zero raises `TempoError`.
+pub fn Duration::divide(
+  self : Duration,
+  n : Int64,
+) -> Duration raise TempoError {
+  if n == 0L {
+    raise TempoError("duration division by zero")
+  }
+  { nanoseconds: self.nanoseconds / n }
+}
 
 ///|
 pub impl Add for Duration with fn add(self, other : Duration) -> Duration {

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -947,13 +947,18 @@ pub fn Duration::checked_multiply(self : Duration, n : Int64) -> Duration? {
 ///|
 /// Divide this duration by an `Int64` scalar, truncating toward zero.
 ///
-/// Division by zero raises `TempoError`.
+/// Division by zero raises `TempoError`. The `Int64::min_value / -1` overflow
+/// edge also raises `TempoError` instead of trapping on backends where signed
+/// division overflow is a runtime error.
 pub fn Duration::divide(
   self : Duration,
   n : Int64,
 ) -> Duration raise TempoError {
   if n == 0L {
     raise TempoError("duration division by zero")
+  }
+  if self.nanoseconds == int64_min_value && n == -1L {
+    raise TempoError("duration division overflow")
   }
   { nanoseconds: self.nanoseconds / n }
 }

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -878,6 +878,80 @@ test "Duration op_neg" {
 }
 
 ///|
+test "Duration::abs" {
+  assert_eq(@tempo.Duration::seconds(-5L).abs(), @tempo.Duration::seconds(5L))
+  assert_eq(@tempo.Duration::seconds(5L).abs(), @tempo.Duration::seconds(5L))
+  assert_eq(@tempo.Duration::seconds(0L).abs(), @tempo.Duration::seconds(0L))
+  assert_eq(
+    @tempo.Duration::nanoseconds(-9_223_372_036_854_775_808L).abs(),
+    @tempo.Duration::nanoseconds(9_223_372_036_854_775_807L),
+  )
+}
+
+///|
+test "Duration::is_positive" {
+  assert_eq(@tempo.Duration::seconds(1L).is_positive(), true)
+  assert_eq(@tempo.Duration::seconds(0L).is_positive(), false)
+  assert_eq(@tempo.Duration::seconds(-1L).is_positive(), false)
+}
+
+///|
+test "Duration::signum" {
+  assert_eq(@tempo.Duration::seconds(-1L).signum(), -1)
+  assert_eq(@tempo.Duration::seconds(0L).signum(), 0)
+  assert_eq(@tempo.Duration::seconds(1L).signum(), 1)
+}
+
+///|
+test "Duration::multiply" {
+  assert_eq(
+    @tempo.Duration::seconds(2L).multiply(3L),
+    @tempo.Duration::seconds(6L),
+  )
+  assert_eq(
+    @tempo.Duration::seconds(2L).multiply(-1L),
+    @tempo.Duration::seconds(-2L),
+  )
+  assert_eq(
+    @tempo.Duration::seconds(2L).multiply(0L),
+    @tempo.Duration::seconds(0L),
+  )
+}
+
+///|
+test "Duration::checked_multiply" {
+  assert_true(
+    @tempo.Duration::seconds(2L).checked_multiply(3L) ==
+    Some(@tempo.Duration::seconds(6L)),
+  )
+  assert_true(
+    @tempo.Duration::nanoseconds(9_223_372_036_854_775_807L).checked_multiply(
+      2L,
+    )
+    is None,
+  )
+  assert_true(
+    @tempo.Duration::nanoseconds(-9_223_372_036_854_775_808L).checked_multiply(
+      -1L,
+    )
+    is None,
+  )
+}
+
+///|
+test "Duration::divide" {
+  assert_eq(
+    @tempo.Duration::seconds(6L).divide(2L),
+    @tempo.Duration::seconds(3L),
+  )
+  assert_eq(
+    @tempo.Duration::nanoseconds(7L).divide(2L),
+    @tempo.Duration::nanoseconds(3L),
+  )
+  assert_true((try? @tempo.Duration::seconds(1L).divide(0L)) is Err(_))
+}
+
+///|
 test "Duration compare" {
   let a = @tempo.Duration::seconds(1L)
   let b = @tempo.Duration::seconds(2L)

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -949,6 +949,10 @@ test "Duration::divide" {
     @tempo.Duration::nanoseconds(3L),
   )
   assert_true((try? @tempo.Duration::seconds(1L).divide(0L)) is Err(_))
+  assert_true(
+    (try? @tempo.Duration::nanoseconds(-9_223_372_036_854_775_808L).divide(-1L))
+    is Err(_),
+  )
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -916,6 +916,10 @@ test "Duration::multiply" {
     @tempo.Duration::seconds(2L).multiply(0L),
     @tempo.Duration::seconds(0L),
   )
+  assert_eq(
+    @tempo.Duration::nanoseconds(9_223_372_036_854_775_807L).multiply(2L),
+    @tempo.Duration::nanoseconds(-2L),
+  )
 }
 
 ///|
@@ -936,6 +940,12 @@ test "Duration::checked_multiply" {
     )
     is None,
   )
+  assert_true(
+    @tempo.Duration::nanoseconds(9_223_372_036_854_775_807L).checked_multiply(
+      0L,
+    ) ==
+    Some(@tempo.Duration::nanoseconds(0L)),
+  )
 }
 
 ///|
@@ -946,6 +956,18 @@ test "Duration::divide" {
   )
   assert_eq(
     @tempo.Duration::nanoseconds(7L).divide(2L),
+    @tempo.Duration::nanoseconds(3L),
+  )
+  assert_eq(
+    @tempo.Duration::nanoseconds(-7L).divide(2L),
+    @tempo.Duration::nanoseconds(-3L),
+  )
+  assert_eq(
+    @tempo.Duration::nanoseconds(7L).divide(-2L),
+    @tempo.Duration::nanoseconds(-3L),
+  )
+  assert_eq(
+    @tempo.Duration::nanoseconds(-7L).divide(-2L),
     @tempo.Duration::nanoseconds(3L),
   )
   assert_true((try? @tempo.Duration::seconds(1L).divide(0L)) is Err(_))


### PR DESCRIPTION
Closes beads tempo-z7j.1 and tempo-z7j.2.\n\nAdds Duration sign helpers (abs with Int64 min saturation, is_positive, signum) and Int64 scalar arithmetic (multiply, checked_multiply, divide).\n\nVerification: moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: 300b4f86ae400963a5e73db6d14649d433efdf13
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: 300b4f86ae400963a5e73db6d14649d433efdf13
  - output tail:
```text
Total tests: 179, passed: 179, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: 300b4f86ae400963a5e73db6d14649d433efdf13
  - output tail:
```text
Total tests: 179, passed: 179, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: 300b4f86ae400963a5e73db6d14649d433efdf13
  - output tail:
```text
Total tests: 179, passed: 179, failed: 0.
```