### PR TITLE
Add DateTime Unix millis and micros interop

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -48,6 +48,8 @@ pub fn DateTime::end_of_month(Self) -> Self
 pub fn DateTime::end_of_year(Self) -> Self
 pub fn DateTime::epoch() -> Self
 pub fn DateTime::format(Self) -> String
+pub fn DateTime::from_unix_micros(Int64) -> Self
+pub fn DateTime::from_unix_millis(Int64) -> Self
 pub fn DateTime::from_unix_nanos(Int64) -> Self
 pub fn DateTime::from_unix_seconds(Int64) -> Self
 pub fn DateTime::new(Date, Time) -> Self
@@ -58,6 +60,8 @@ pub fn DateTime::start_of_year(Self) -> Self
 pub fn DateTime::sub(Self, Duration) -> Self
 pub fn DateTime::to_date(Self) -> Date
 pub fn DateTime::to_time(Self) -> Time
+pub fn DateTime::to_unix_micros(Self) -> Int64
+pub fn DateTime::to_unix_millis(Self) -> Int64
 pub fn DateTime::to_unix_nanos(Self) -> Int64
 pub fn DateTime::to_unix_seconds(Self) -> Int64
 pub fn DateTime::with_date(Self, Date) -> Self

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -733,6 +733,20 @@ pub fn DateTime::from_unix_nanos(ns : Int64) -> DateTime {
 }
 
 ///|
+/// Convert a Unix timestamp in milliseconds to a `DateTime`.
+/// Negative values represent dates before the Unix epoch.
+pub fn DateTime::from_unix_millis(ms : Int64) -> DateTime {
+  DateTime::from_unix_nanos(ms * 1_000_000L)
+}
+
+///|
+/// Convert a Unix timestamp in microseconds to a `DateTime`.
+/// Negative values represent dates before the Unix epoch.
+pub fn DateTime::from_unix_micros(us : Int64) -> DateTime {
+  DateTime::from_unix_nanos(us * 1_000L)
+}
+
+///|
 /// Convert this DateTime to a Unix timestamp in seconds (nanoseconds truncated).
 pub fn DateTime::to_unix_seconds(self : DateTime) -> Int64 {
   let days = days_from_civil(self.date.year, self.date.month, self.date.day)
@@ -749,6 +763,19 @@ pub fn DateTime::to_unix_seconds(self : DateTime) -> Int64 {
 /// `to_unix_seconds` instead.
 pub fn DateTime::to_unix_nanos(self : DateTime) -> Int64 {
   self.to_unix_seconds() * 1_000_000_000L + self.time.nanosecond.to_int64()
+}
+
+///|
+/// Convert this `DateTime` to a Unix timestamp in milliseconds.
+pub fn DateTime::to_unix_millis(self : DateTime) -> Int64 {
+  self.to_unix_seconds() * 1000L + (self.time.nanosecond / 1_000_000).to_int64()
+}
+
+///|
+/// Convert this `DateTime` to a Unix timestamp in microseconds.
+pub fn DateTime::to_unix_micros(self : DateTime) -> Int64 {
+  self.to_unix_seconds() * 1_000_000L +
+  (self.time.nanosecond / 1_000).to_int64()
 }
 
 // ─── Duration constructors ────────────────────────────────────────────────────

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -736,14 +736,20 @@ pub fn DateTime::from_unix_nanos(ns : Int64) -> DateTime {
 /// Convert a Unix timestamp in milliseconds to a `DateTime`.
 /// Negative values represent dates before the Unix epoch.
 pub fn DateTime::from_unix_millis(ms : Int64) -> DateTime {
-  DateTime::from_unix_nanos(ms * 1_000_000L)
+  let ts_sec = floor_div64(ms, 1000L)
+  let nanosecond = ((ms - ts_sec * 1000L) * ns_per_ms).to_int()
+  let dt = DateTime::from_unix_seconds(ts_sec)
+  { ..dt, time: { ..dt.time, nanosecond, } }
 }
 
 ///|
 /// Convert a Unix timestamp in microseconds to a `DateTime`.
 /// Negative values represent dates before the Unix epoch.
 pub fn DateTime::from_unix_micros(us : Int64) -> DateTime {
-  DateTime::from_unix_nanos(us * 1_000L)
+  let ts_sec = floor_div64(us, 1_000_000L)
+  let nanosecond = ((us - ts_sec * 1_000_000L) * ns_per_us).to_int()
+  let dt = DateTime::from_unix_seconds(ts_sec)
+  { ..dt, time: { ..dt.time, nanosecond, } }
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -558,6 +558,57 @@ test "to_unix_nanos roundtrip" {
 }
 
 ///|
+test "from_unix_millis epoch" {
+  assert_eq(@tempo.DateTime::from_unix_millis(0L), @tempo.DateTime::epoch())
+  assert_eq(@tempo.DateTime::epoch().to_unix_millis(), 0L)
+}
+
+///|
+test "from_unix_millis fractional roundtrip" {
+  let ms = 1500L
+  assert_eq(@tempo.DateTime::from_unix_millis(ms).to_unix_millis(), ms)
+}
+
+///|
+test "from_unix_millis negative roundtrip" {
+  let ms = -500L
+  assert_eq(@tempo.DateTime::from_unix_millis(ms).to_unix_millis(), ms)
+}
+
+///|
+test "from_unix_micros epoch plus one second" {
+  assert_eq(
+    @tempo.DateTime::from_unix_micros(1_000_000L),
+    @tempo.DateTime::from_unix_seconds(1L),
+  )
+}
+
+///|
+test "from_unix_micros fractional roundtrip" {
+  let us = 2_500_000L
+  assert_eq(@tempo.DateTime::from_unix_micros(us).to_unix_micros(), us)
+}
+
+///|
+test "from_unix_micros negative roundtrip" {
+  let us = -1_500_000L
+  assert_eq(@tempo.DateTime::from_unix_micros(us).to_unix_micros(), us)
+}
+
+///|
+test "to_unix_millis uses floor seconds plus subsecond millis" {
+  let dt = @tempo.DateTime::from_unix_nanos(1710506096_123_456_789L)
+  assert_eq(dt.to_unix_millis(), dt.to_unix_seconds() * 1000L + 123L)
+}
+
+///|
+test "to_unix_millis and micros support wide range" {
+  let dt = @tempo.DateTime::parse("3000-01-01T00:00:00Z")
+  assert_eq(dt.to_unix_millis(), 32_503_680_000_000L)
+  assert_eq(dt.to_unix_micros(), 32_503_680_000_000_000L)
+}
+
+///|
 test "DateTime::format no sub-second" {
   let dt = @tempo.DateTime::from_unix_seconds(0L)
   assert_eq(dt.format(), "1970-01-01T00:00:00Z")

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -604,8 +604,12 @@ test "to_unix_millis uses floor seconds plus subsecond millis" {
 ///|
 test "to_unix_millis and micros support wide range" {
   let dt = @tempo.DateTime::parse("3000-01-01T00:00:00Z")
-  assert_eq(dt.to_unix_millis(), 32_503_680_000_000L)
-  assert_eq(dt.to_unix_micros(), 32_503_680_000_000_000L)
+  let ms = 32_503_680_000_000L
+  let us = 32_503_680_000_000_000L
+  assert_eq(dt.to_unix_millis(), ms)
+  assert_eq(dt.to_unix_micros(), us)
+  assert_eq(@tempo.DateTime::from_unix_millis(ms), dt)
+  assert_eq(@tempo.DateTime::from_unix_micros(us), dt)
 }
 
 ///|


### PR DESCRIPTION
Closes tempo-4h4.1 and tempo-4h4.2.\n\nAdds DateTime::from_unix_millis/to_unix_millis and DateTime::from_unix_micros/to_unix_micros. The from_* helpers follow the nanos-backed scaling design from the beads, while the to_* helpers use to_unix_seconds() plus the non-negative fractional nanosecond component so wide DateTime values such as year 3000 convert without routing through to_unix_nanos().\n\nVerification:\n- moon fmt --check\n- moon test --target wasm-gc\n- moon test --target js\n- moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: d066da6744a73539f5ca614f925b02adbb459e53
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: d066da6744a73539f5ca614f925b02adbb459e53
  - output tail:
```text
Total tests: 187, passed: 187, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: d066da6744a73539f5ca614f925b02adbb459e53
  - output tail:
```text
Total tests: 187, passed: 187, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: d066da6744a73539f5ca614f925b02adbb459e53
  - output tail:
```text
Total tests: 187, passed: 187, failed: 0.
```