### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ You can browse and install extra skills here:
   blackbox test files (ending in `_test.mbt`) and whitebox test files (ending in
   `_wbtest.mbt`).
 
-- In the toplevel directory, there is a `moon.mod.json` file listing module
+- In the toplevel directory, there is a `moon.mod` file listing module
   metadata.
 
 ## Coding convention

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.0] - 2026-06-02
+
+### Added
+
+- `DateTime::parse` accepts fixed RFC 3339 numeric offsets (e.g.
+  `2024-07-21T17:11:00-04:00`) and normalizes them to UTC. Out-of-range offsets
+  raise `TempoError`. The original offset is not retained. (#14)
+- `Date::add_months` and `Date::add_years`, with end-of-month clamping
+  (`2024-01-31` + 1 month = `2024-02-29`; clamping is non-sticky). (#15)
+- Month and year boundary adjusters on `Date` and `DateTime`: `start_of_month`,
+  `end_of_month`, `start_of_year`, `end_of_year`. The `DateTime` variants adjust
+  the date and preserve the time of day. (#16)
+- `DateTime::to_date` and `DateTime::to_time` accessors. (#17)
+- Immutable field updaters: `Date::with_year`/`with_month`/`with_day`,
+  `Time::with_hour`/`with_minute`/`with_second`/`with_nanosecond`, and
+  `DateTime::with_date`/`with_time` plus `with_year` through `with_nanosecond`.
+  The fallible updaters validate through `Date::new`/`Time::new` and raise on an
+  invalid result rather than clamping. (#17)
+- `Weekday` (Monday–Sunday) and `Month` (January–December) enums deriving `Eq`,
+  `Compare`, `Hash`, and `Show`, with `to_int`/`from_int`, cyclic
+  `next`/`previous`, `Weekday::number_from_monday`/`number_from_sunday`, and
+  `Month::days_in`. `Date::weekday` and `Date::month_enum` return them;
+  `Date::day_of_week` (returning `Int`) is unchanged. (#18)
+- `Duration::abs`, `is_positive`, `signum`, `multiply`, `checked_multiply`, and
+  `divide`. `abs` saturates `Int64::min_value` to `Int64::max_value`; `multiply`
+  wraps on overflow while `checked_multiply` returns `None`; `divide` truncates
+  toward zero and raises on division by zero and on the `Int64::min_value / -1`
+  overflow. (#19)
+- `DateTime::from_unix_millis`/`to_unix_millis` and
+  `from_unix_micros`/`to_unix_micros`. The conversions split into whole seconds
+  plus a bounded sub-second remainder, so they hold across the full date range
+  rather than only the ~292-year nanosecond window. (#20)
+
+### Changed
+
+- Migrated the module manifest from `moon.mod.json` to the TOML `moon.mod`, and
+  trait implementations to the `with fn` syntax, for the May 2026 MoonBit
+  toolchain. (#13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DateTime::with_date`/`with_time` plus `with_year` through `with_nanosecond`.
   The fallible updaters validate through `Date::new`/`Time::new` and raise on an
   invalid result rather than clamping. (#17)
-- `Weekday` (Monday–Sunday) and `Month` (January–December) enums deriving `Eq`,
+- `Weekday` (Monday–Sunday) and `Month` (January–December) enums implementing `Eq`,
   `Compare`, `Hash`, and `Show`, with `to_int`/`from_int`, cyclic
   `next`/`previous`, `Weekday::number_from_monday`/`number_from_sunday`, and
   `Month::days_in`. `Date::weekday` and `Date::month_enum` return them;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,19 +48,53 @@ Added to all public functions.
 
 ---
 
-## v0.3 — next
+## v0.4 — shipped
+
+**Fixed-offset parsing**
+`DateTime::parse` accepts RFC 3339 numeric offsets (`-04:00`, `+09:00`) and
+normalizes to UTC.
+
+**Calendar arithmetic**
+`Date::add_months`, `Date::add_years` (end-of-month clamping);
+`start_of_month` / `end_of_month` / `start_of_year` / `end_of_year` on `Date`
+and `DateTime`.
+
+**Field updaters & accessors**
+`with_year` … `with_nanosecond` on `Date` / `Time` / `DateTime`;
+`DateTime::to_date` / `to_time`.
+
+**Typed enums**
+`Weekday` and `Month` (Int conversions, navigation); `Date::weekday`,
+`Date::month_enum`.
+
+**Duration scalar ops**
+`abs`, `is_positive`, `signum`, `multiply`, `checked_multiply`, `divide`.
+
+**Timestamp interop**
+`from_unix_millis` / `to_unix_millis`, `from_unix_micros` / `to_unix_micros`.
+
+---
+
+## next
 
 **Sub-second `now()` on native**
-See v0.2. Requires a `.c` stub in the build.
+Requires a `.c` stub in the build.
 
-**`Date::parse` / `Date::format`**
-Date-only strings: `2026-03-28`.
+**`FixedOffsetDateTime`**
+Retain the display offset instead of normalizing to UTC.
 
-**`Time::parse` / `Time::format`**
-Time-only strings: `14:31:43`, `14:31:43.123Z`.
+**Calendar-aware `Period` / `YearMonth`**
+Year/month durations distinct from the nanosecond `Duration`.
 
-**Docstring coverage**
-Public API docstrings are sparse.
+**Rounding & comparison helpers**
+`truncate_to` / `round_to`, `start_of_day`, `is_before` / `is_after` / `clamp`,
+date intervals.
+
+**ISO week & ordinal dates**
+`iso_week`, `from_ordinal`, week-date / ordinal string formats.
+
+**Hash & JSON**
+`derive(Hash)` for map keys; `ToJson` / `FromJson`.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,6 +48,13 @@ Added to all public functions.
 
 ---
 
+## v0.3 — shipped
+
+Maintenance and toolchain compatibility (JS backend `Int64` FFI, MoonBit
+toolchain updates).
+
+---
+
 ## v0.4 — shipped
 
 **Fixed-offset parsing**

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "brickfrog/tempo"
 
-version = "0.3.4"
+version = "0.4.0"
 
 readme = "README.mbt.md"
 


### PR DESCRIPTION
Release prep for **v0.4.0**.

- `CHANGELOG.md` — new, documenting the 0.4.0 additions (offset parsing, calendar arithmetic, boundary adjusters, field updaters, `Weekday`/`Month` enums, `Duration` scalar ops, millis/micros interop) and the manifest migration.
- `moon.mod` — version `0.3.4` → `0.4.0`.
- `ROADMAP.md` — mark v0.4 shipped; refresh the next/deferred lists.

Docs/version only — no source changes. Tag, GitHub Release, and `moon publish` follow after merge.
