### PR TITLE
docs: README v0.4 features + CHANGELOG history backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated the module manifest from `moon.mod.json` to the TOML `moon.mod`, and
   trait implementations to the `with fn` syntax, for the May 2026 MoonBit
   toolchain. (#13)
+
+## [0.3.4] - 2026-05-13
+
+### Fixed
+- Compatibility with the May 2026 MoonBit toolchain.
+
+## [0.3.3] - 2026-04-29
+
+### Changed
+- Replaced a deprecated `StringView` allocation.
+
+## [0.3.2] - 2026-04-12
+
+### Fixed
+- `Duration::to_string_repr` guards `Int64::min_value`, which cannot be negated.
+
+## [0.3.1] - 2026-04-08
+
+### Fixed
+- JS backend: `Int64` FFI returns `BigInt` directly, for newer-runtime compatibility.
+
+## [0.3.0] - 2026-04-08
+
+### Added
+- `Duration::is_zero`, `Duration::is_negative`, and the `Duration::as_days` accessor.
+
+## [0.2.3] - 2026-04-05
+
+### Changed
+- Internal test coverage and design documentation.
+
+## [0.2.2] - 2026-03-31
+
+### Changed
+- Internal migration from `loop` to `for`.
+
+## [0.2.1] - 2026-03-28
+
+### Fixed
+- Added the `source` field to the manifest so the package resolves as `@tempo`.
+
+## [0.2.0] - 2026-03-28
+
+### Added
+- `Date::parse` / `Date::format` for date-only strings (`2024-03-28`).
+- `Time::parse` / `Time::format` for time-only strings (`14:31:43`, `14:31:43.123`).
+- `Date` calendar arithmetic: `add_days`, `day_of_week`, `day_of_year`, `days_until`.
+- `Duration::weeks` constructor and `Duration::as_weeks` accessor.
+- ISO 8601 expanded-year formatting for negative years.
+
+## [0.1.0] - 2026-03-28
+
+### Added
+- Core types `Date`, `Time`, `DateTime`, `Duration`.
+- RFC 3339 / ISO 8601 `DateTime::parse` and `DateTime::format`.
+- Unix timestamp conversion: `from_unix_seconds`/`from_unix_nanos` and `to_unix_seconds`/`to_unix_nanos`.
+- `DateTime` arithmetic (`add`, `sub`, `diff`) and `Duration` operators.
+- `Duration` constructors (`nanoseconds` … `days`) and accessors (`as_nanoseconds` … `as_hours`).
+- `DateTime::now` (POSIX `time(2)` on native, `Date.now()` on js/wasm-gc).
+- `Show`, `Eq`, `Compare` for all types.
+- Calendar helpers `is_leap_year` and `days_in_month`.

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -1,7 +1,7 @@
 # tempo
 
 UTC date/time library for MoonBit. RFC 3339 parsing, Unix timestamp conversion,
-basic arithmetic. No external dependencies.
+calendar and duration arithmetic. No external dependencies.
 
 In your `moon.pkg`:
 
@@ -47,14 +47,26 @@ test {
 }
 ```
 
+## Unix timestamps
+
 ```moonbit nocheck
 ///|
 test {
   let dt = @tempo.DateTime::from_unix_seconds(0L)
   inspect(dt.format(), content="1970-01-01T00:00:00Z")
+  inspect(dt.to_unix_seconds(), content="0")
 
   let dt2 = @tempo.DateTime::from_unix_nanos(1_000_000_000L)
   inspect(dt2.format(), content="1970-01-01T00:00:01Z")
+  inspect(dt2.to_unix_nanos(), content="1000000000")
+
+  let ms = @tempo.DateTime::from_unix_millis(1500L)
+  inspect(ms.format(), content="1970-01-01T00:00:01.5Z")
+  inspect(ms.to_unix_millis(), content="1500")
+
+  let us = @tempo.DateTime::from_unix_micros(1_500_250L)
+  inspect(us.format(), content="1970-01-01T00:00:01.50025Z")
+  inspect(us.to_unix_micros(), content="1500250")
 }
 ```
 
@@ -62,7 +74,7 @@ test {
 
 Accepts RFC 3339 / ISO 8601. UTC markers (`Z`, `+00:00`, `-00:00`) and fixed
 numeric offsets are accepted. Parsed values are stored as UTC `DateTime`s; the
-original offset is not retained.
+original offset is not retained. Out-of-range offsets raise `TempoError`.
 
 ```moonbit nocheck
 ///|
@@ -75,8 +87,8 @@ test {
 ```moonbit nocheck
 ///|
 test {
-  let dt = @tempo.DateTime::parse("2026-03-28T14:31:43+09:00")
-  inspect(dt.format(), content="2026-03-28T05:31:43Z")
+  let dt = @tempo.DateTime::parse("2024-07-21T17:11:00-04:00")
+  inspect(dt.format(), content="2024-07-21T21:11:00Z")
 }
 ```
 
@@ -157,10 +169,42 @@ test {
   assert_eq(@tempo.Duration::seconds(1L).is_zero(), false)
   assert_eq(@tempo.Duration::seconds(-1L).is_negative(), true)
   assert_eq(@tempo.Duration::seconds(1L).is_negative(), false)
+  assert_eq(@tempo.Duration::seconds(1L).is_positive(), true)
 }
 ```
 
-## Date arithmetic
+## Duration arithmetic
+
+`Duration::abs`, `is_positive`, `signum`, `multiply`, `checked_multiply`, and
+`divide` cover common signed-duration operations.
+`Duration::divide` raises on division by zero and on the
+`Int64::min_value / -1` overflow.
+
+```moonbit nocheck
+///|
+test {
+  let d = @tempo.Duration::seconds(-3L)
+  inspect(d.abs().as_seconds(), content="3")
+  assert_eq(d.signum(), -1)
+
+  let doubled = @tempo.Duration::seconds(2L).multiply(3L)
+  inspect(doubled.as_seconds(), content="6")
+  assert_eq(
+    @tempo.Duration::seconds(2L).checked_multiply(3L),
+    Some(@tempo.Duration::seconds(6L)),
+  )
+
+  let half = @tempo.Duration::seconds(7L).divide(2L)
+  inspect(half.as_seconds(), content="3")
+}
+```
+
+## Calendar arithmetic
+
+`Date::add_months` and `Date::add_years` clamp to the end of the target month
+when needed. `Date` and `DateTime` both provide `start_of_month`,
+`end_of_month`, `start_of_year`, and `end_of_year`; the `DateTime` variants
+adjust the date and preserve the time of day.
 
 ```moonbit nocheck
 ///|
@@ -180,6 +224,77 @@ test {
   // Days between two dates
   let other = @tempo.Date::new(2024, 3, 1)
   assert_eq(d.days_until(other), -14)
+}
+```
+
+```moonbit nocheck
+///|
+test {
+  let end = @tempo.Date::new(2024, 1, 31)
+  inspect(end.add_months(1).format(), content="2024-02-29")
+
+  let leap = @tempo.Date::new(2024, 2, 29)
+  inspect(leap.add_years(1).format(), content="2025-02-28")
+
+  let mid = @tempo.Date::new(2024, 3, 15)
+  inspect(mid.start_of_month().format(), content="2024-03-01")
+  inspect(mid.end_of_month().format(), content="2024-03-31")
+  inspect(mid.start_of_year().format(), content="2024-01-01")
+  inspect(mid.end_of_year().format(), content="2024-12-31")
+
+  let dt = @tempo.DateTime::parse("2024-03-15T14:31:43Z")
+  inspect(dt.start_of_month().format(), content="2024-03-01T14:31:43Z")
+  inspect(dt.end_of_year().format(), content="2024-12-31T14:31:43Z")
+}
+```
+
+## Field updaters
+
+`DateTime::to_date` and `DateTime::to_time` split a timestamp into its parts.
+`Date` has `with_year`/`with_month`/`with_day`; `Time` has `with_hour` through
+`with_nanosecond`; `DateTime` has `with_date`/`with_time` plus `with_year`
+through `with_nanosecond`. Fallible updaters raise on invalid values rather
+than clamping.
+
+```moonbit nocheck
+///|
+test {
+  let d = @tempo.Date::new(2024, 3, 15)
+  inspect(d.with_day(1).format(), content="2024-03-01")
+
+  let t = @tempo.Time::new(14, 31, 43, 125_000_000)
+  inspect(t.with_nanosecond(0).format(), content="14:31:43")
+
+  let dt = @tempo.DateTime::new(d, t)
+  inspect(dt.to_date().format(), content="2024-03-15")
+  inspect(dt.to_time().format(), content="14:31:43.125")
+  inspect(
+    dt.with_year(2025).with_hour(9).format(),
+    content="2025-03-15T09:31:43.125Z",
+  )
+}
+```
+
+## Weekday and Month
+
+`Date::weekday` and `Date::month_enum` return enums. `Weekday` and `Month` use
+1-based numbers for `to_int`/`from_int`; `next` and `previous` wrap around.
+
+```moonbit nocheck
+///|
+test {
+  let d = @tempo.Date::new(2024, 3, 15)
+  assert_eq(d.weekday(), @tempo.Friday)
+  assert_eq(d.month_enum(), @tempo.March)
+
+  assert_eq(@tempo.Friday.to_int(), 5)
+  assert_eq(@tempo.Weekday::from_int(5), Some(@tempo.Friday))
+  assert_eq(@tempo.Friday.next(), @tempo.Saturday)
+  assert_eq(@tempo.Monday.previous(), @tempo.Sunday)
+
+  assert_eq(@tempo.February.to_int(), 2)
+  assert_eq(@tempo.Month::from_int(2), Some(@tempo.February))
+  assert_eq(@tempo.February.days_in(2024), 29)
 }
 ```
 


### PR DESCRIPTION
Documentation follow-up for v0.4.0 (no source changes).

- `README.mbt.md` — fix the stale "non-UTC offsets are rejected" claim (they're now normalized to UTC), and add sections for the v0.4 surface: calendar arithmetic, boundary adjusters, field updaters/accessors, `Weekday`/`Month` enums, `Duration` arithmetic, and millis/micros interop.
- `CHANGELOG.md` — backfill the release history from `0.1.0` through `0.3.4`.

Diff touches only `README.mbt.md` and `CHANGELOG.md`; `.mbti` unchanged. Verify green on wasm-gc/js/native.
