### PR TITLE
Add DateTime day boundary truncation

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -151,7 +151,8 @@ pub(all) enum TimeUnit {
   Minute
   Hour
   Day
-} derive(Compare, Eq, Hash, Show)
+} derive(Compare, Eq, Hash)
+pub impl Show for TimeUnit
 
 pub(all) enum Weekday {
   Monday

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -44,6 +44,7 @@ pub struct DateTime {
 } derive(Compare, Eq)
 pub fn DateTime::add(Self, Duration) -> Self
 pub fn DateTime::diff(Self, Self) -> Duration
+pub fn DateTime::end_of_day(Self) -> Self
 pub fn DateTime::end_of_month(Self) -> Self
 pub fn DateTime::end_of_year(Self) -> Self
 pub fn DateTime::epoch() -> Self
@@ -55,6 +56,7 @@ pub fn DateTime::from_unix_seconds(Int64) -> Self
 pub fn DateTime::new(Date, Time) -> Self
 pub fn DateTime::now() -> Self
 pub fn DateTime::parse(String) -> Self raise TempoError
+pub fn DateTime::start_of_day(Self) -> Self
 pub fn DateTime::start_of_month(Self) -> Self
 pub fn DateTime::start_of_year(Self) -> Self
 pub fn DateTime::sub(Self, Duration) -> Self
@@ -64,6 +66,7 @@ pub fn DateTime::to_unix_micros(Self) -> Int64
 pub fn DateTime::to_unix_millis(Self) -> Int64
 pub fn DateTime::to_unix_nanos(Self) -> Int64
 pub fn DateTime::to_unix_seconds(Self) -> Int64
+pub fn DateTime::truncate_to(Self, TimeUnit) -> Self
 pub fn DateTime::with_date(Self, Date) -> Self
 pub fn DateTime::with_day(Self, Int) -> Self raise TempoError
 pub fn DateTime::with_hour(Self, Int) -> Self raise TempoError
@@ -142,6 +145,13 @@ pub fn Time::with_minute(Self, Int) -> Self raise TempoError
 pub fn Time::with_nanosecond(Self, Int) -> Self raise TempoError
 pub fn Time::with_second(Self, Int) -> Self raise TempoError
 pub impl Show for Time
+
+pub(all) enum TimeUnit {
+  Second
+  Minute
+  Hour
+  Day
+} derive(Compare, Eq, Hash, Show)
 
 pub(all) enum Weekday {
   Monday

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -255,6 +255,15 @@ pub struct Time {
 } derive(Eq, Compare)
 
 ///|
+/// Units supported by `DateTime::truncate_to`, ordered smallest to largest.
+pub(all) enum TimeUnit {
+  Second
+  Minute
+  Hour
+  Day
+} derive(Eq, Compare, Hash, Show)
+
+///|
 /// A combined UTC date and time.
 pub struct DateTime {
   date : Date
@@ -702,6 +711,36 @@ pub fn DateTime::start_of_year(self : DateTime) -> DateTime {
 /// midnight is desired.
 pub fn DateTime::end_of_year(self : DateTime) -> DateTime {
   DateTime::new(self.date.end_of_year(), self.time)
+}
+
+///|
+/// Return this DateTime at the start of its calendar day.
+pub fn DateTime::start_of_day(self : DateTime) -> DateTime {
+  { ..self, time: { hour: 0, minute: 0, second: 0, nanosecond: 0 } }
+}
+
+///|
+/// Return this DateTime at the end of its calendar day.
+pub fn DateTime::end_of_day(self : DateTime) -> DateTime {
+  {
+    ..self,
+    time: { hour: 23, minute: 59, second: 59, nanosecond: 999_999_999 },
+  }
+}
+
+///|
+/// Floor this DateTime to the requested unit boundary.
+///
+/// Day truncation is anchored to the calendar day: it returns midnight UTC on
+/// the same date, rather than truncating a duration since the Unix epoch.
+pub fn DateTime::truncate_to(self : DateTime, unit : TimeUnit) -> DateTime {
+  match unit {
+    Second => { ..self, time: { ..self.time, nanosecond: 0 } }
+    Minute => { ..self, time: { ..self.time, second: 0, nanosecond: 0 } }
+    Hour =>
+      { ..self, time: { ..self.time, minute: 0, second: 0, nanosecond: 0 } }
+    Day => self.start_of_day()
+  }
 }
 
 // ─── Unix timestamp conversion ────────────────────────────────────────────────

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -261,7 +261,17 @@ pub(all) enum TimeUnit {
   Minute
   Hour
   Day
-} derive(Eq, Compare, Hash, Show)
+} derive(Eq, Compare, Hash)
+
+///|
+pub impl Show for TimeUnit with fn output(self, logger) {
+  match self {
+    Second => logger.write_string("Second")
+    Minute => logger.write_string("Minute")
+    Hour => logger.write_string("Hour")
+    Day => logger.write_string("Day")
+  }
+}
 
 ///|
 /// A combined UTC date and time.

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -217,6 +217,32 @@ test "DateTime boundary adjusters preserve time of day" {
 }
 
 ///|
+test "DateTime day boundary adjusters set time of day" {
+  let dt = @tempo.DateTime::parse("2024-03-15T14:31:43.125Z")
+  assert_eq(dt.start_of_day().format(), "2024-03-15T00:00:00Z")
+  assert_eq(dt.end_of_day().format(), "2024-03-15T23:59:59.999999999Z")
+  assert_eq(dt.start_of_day().date, dt.date)
+  assert_eq(dt.end_of_day().date, dt.date)
+}
+
+///|
+test "DateTime truncate_to floors to unit boundary" {
+  let dt = @tempo.DateTime::parse("2024-03-15T14:31:43.125Z")
+  assert_eq(dt.truncate_to(@tempo.Second).format(), "2024-03-15T14:31:43Z")
+  assert_eq(dt.truncate_to(@tempo.Minute).format(), "2024-03-15T14:31:00Z")
+  assert_eq(dt.truncate_to(@tempo.Hour).format(), "2024-03-15T14:00:00Z")
+  assert_eq(dt.truncate_to(@tempo.Day), dt.start_of_day())
+  assert_eq(dt.truncate_to(@tempo.Hour).date, dt.date)
+}
+
+///|
+test "DateTime truncate_to day is calendar anchored for far future dates" {
+  let dt = @tempo.DateTime::parse("3000-01-01T14:31:43.125Z")
+  assert_eq(dt.truncate_to(@tempo.Day).format(), "3000-01-01T00:00:00Z")
+  assert_eq(dt.truncate_to(@tempo.Hour).format(), "3000-01-01T14:00:00Z")
+}
+
+///|
 test "DateTime accessors and component updaters" {
   let date = @tempo.Date::new(2024, 3, 15)
   let time = @tempo.Time::new(12, 34, 56, 789)


### PR DESCRIPTION
Closes tempo-5nc.1 and tempo-5nc.2.\n\nAdds TimeUnit plus DateTime::start_of_day, DateTime::end_of_day, and DateTime::truncate_to using pure time-field updates anchored to the same calendar date. Includes blackbox coverage for start/end of day, each truncation unit, date preservation, and a year-3000 overflow-safety case.\n\nVerification: moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: 903711ab53061927d7e559b68de4e34f402cc102
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: 903711ab53061927d7e559b68de4e34f402cc102
  - output tail:
```text
Total tests: 190, passed: 190, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: 903711ab53061927d7e559b68de4e34f402cc102
  - output tail:
```text
Total tests: 190, passed: 190, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: 903711ab53061927d7e559b68de4e34f402cc102
  - output tail:
```text
Total tests: 190, passed: 190, failed: 0.
```