### PR TITLE
Add named comparison helpers

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -21,12 +21,17 @@ pub struct Date {
 pub fn Date::add_days(Self, Int) -> Self
 pub fn Date::add_months(Self, Int) -> Self
 pub fn Date::add_years(Self, Int) -> Self
+pub fn Date::clamp(Self, Self, Self) -> Self
 pub fn Date::day_of_week(Self) -> Int
 pub fn Date::day_of_year(Self) -> Int
 pub fn Date::days_until(Self, Self) -> Int
 pub fn Date::end_of_month(Self) -> Self
 pub fn Date::end_of_year(Self) -> Self
 pub fn Date::format(Self) -> String
+pub fn Date::is_after(Self, Self) -> Bool
+pub fn Date::is_before(Self, Self) -> Bool
+pub fn Date::max(Self, Self) -> Self
+pub fn Date::min(Self, Self) -> Self
 pub fn Date::month_enum(Self) -> Month
 pub fn Date::new(Int, Int, Int) -> Self raise TempoError
 pub fn Date::parse(String) -> Self raise TempoError
@@ -43,6 +48,7 @@ pub struct DateTime {
   time : Time
 } derive(Compare, Eq)
 pub fn DateTime::add(Self, Duration) -> Self
+pub fn DateTime::clamp(Self, Self, Self) -> Self
 pub fn DateTime::diff(Self, Self) -> Duration
 pub fn DateTime::end_of_day(Self) -> Self
 pub fn DateTime::end_of_month(Self) -> Self
@@ -53,9 +59,14 @@ pub fn DateTime::from_unix_micros(Int64) -> Self
 pub fn DateTime::from_unix_millis(Int64) -> Self
 pub fn DateTime::from_unix_nanos(Int64) -> Self
 pub fn DateTime::from_unix_seconds(Int64) -> Self
+pub fn DateTime::is_after(Self, Self) -> Bool
+pub fn DateTime::is_before(Self, Self) -> Bool
+pub fn DateTime::max(Self, Self) -> Self
+pub fn DateTime::min(Self, Self) -> Self
 pub fn DateTime::new(Date, Time) -> Self
 pub fn DateTime::now() -> Self
 pub fn DateTime::parse(String) -> Self raise TempoError
+pub fn DateTime::since(Self, Self) -> Duration
 pub fn DateTime::start_of_day(Self) -> Self
 pub fn DateTime::start_of_month(Self) -> Self
 pub fn DateTime::start_of_year(Self) -> Self
@@ -67,6 +78,7 @@ pub fn DateTime::to_unix_millis(Self) -> Int64
 pub fn DateTime::to_unix_nanos(Self) -> Int64
 pub fn DateTime::to_unix_seconds(Self) -> Int64
 pub fn DateTime::truncate_to(Self, TimeUnit) -> Self
+pub fn DateTime::until(Self, Self) -> Duration
 pub fn DateTime::with_date(Self, Date) -> Self
 pub fn DateTime::with_day(Self, Int) -> Self raise TempoError
 pub fn DateTime::with_hour(Self, Int) -> Self raise TempoError
@@ -137,7 +149,12 @@ pub struct Time {
   second : Int
   nanosecond : Int
 } derive(Compare, Eq)
+pub fn Time::clamp(Self, Self, Self) -> Self
 pub fn Time::format(Self) -> String
+pub fn Time::is_after(Self, Self) -> Bool
+pub fn Time::is_before(Self, Self) -> Bool
+pub fn Time::max(Self, Self) -> Self
+pub fn Time::min(Self, Self) -> Self
 pub fn Time::new(Int, Int, Int, Int) -> Self raise TempoError
 pub fn Time::parse(String) -> Self raise TempoError
 pub fn Time::with_hour(Self, Int) -> Self raise TempoError

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -510,6 +510,50 @@ pub fn Date::days_until(self : Date, other : Date) -> Int {
 }
 
 ///|
+/// `true` if this date is earlier than `other`.
+pub fn Date::is_before(self : Date, other : Date) -> Bool {
+  self.compare(other) < 0
+}
+
+///|
+/// `true` if this date is later than `other`.
+pub fn Date::is_after(self : Date, other : Date) -> Bool {
+  self.compare(other) > 0
+}
+
+///|
+/// Return the earlier of this date and `other`.
+pub fn Date::min(self : Date, other : Date) -> Date {
+  if self.compare(other) <= 0 {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+/// Return the later of this date and `other`.
+pub fn Date::max(self : Date, other : Date) -> Date {
+  if self.compare(other) >= 0 {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+/// Clamp this date to the inclusive range `[lo, hi]`. Assumes `lo <= hi`.
+pub fn Date::clamp(self : Date, lo : Date, hi : Date) -> Date {
+  if self.compare(lo) < 0 {
+    lo
+  } else if self.compare(hi) > 0 {
+    hi
+  } else {
+    self
+  }
+}
+
+///|
 fn floor_mod64(a : Int64, b : Int64) -> Int64 {
   a - floor_div64(a, b) * b
 }
@@ -585,6 +629,50 @@ pub fn Time::with_nanosecond(
   nanosecond : Int,
 ) -> Time raise TempoError {
   Time::new(self.hour, self.minute, self.second, nanosecond)
+}
+
+///|
+/// `true` if this time is earlier than `other`.
+pub fn Time::is_before(self : Time, other : Time) -> Bool {
+  self.compare(other) < 0
+}
+
+///|
+/// `true` if this time is later than `other`.
+pub fn Time::is_after(self : Time, other : Time) -> Bool {
+  self.compare(other) > 0
+}
+
+///|
+/// Return the earlier of this time and `other`.
+pub fn Time::min(self : Time, other : Time) -> Time {
+  if self.compare(other) <= 0 {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+/// Return the later of this time and `other`.
+pub fn Time::max(self : Time, other : Time) -> Time {
+  if self.compare(other) >= 0 {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+/// Clamp this time to the inclusive range `[lo, hi]`. Assumes `lo <= hi`.
+pub fn Time::clamp(self : Time, lo : Time, hi : Time) -> Time {
+  if self.compare(lo) < 0 {
+    lo
+  } else if self.compare(hi) > 0 {
+    hi
+  } else {
+    self
+  }
 }
 
 ///|
@@ -1078,6 +1166,66 @@ pub fn DateTime::sub(self : DateTime, d : Duration) -> DateTime {
 /// Compute `self - other` as a Duration (may be negative).
 pub fn DateTime::diff(self : DateTime, other : DateTime) -> Duration {
   { nanoseconds: self.to_unix_nanos() - other.to_unix_nanos() }
+}
+
+///|
+/// `true` if this DateTime is earlier than `other`.
+pub fn DateTime::is_before(self : DateTime, other : DateTime) -> Bool {
+  self.compare(other) < 0
+}
+
+///|
+/// `true` if this DateTime is later than `other`.
+pub fn DateTime::is_after(self : DateTime, other : DateTime) -> Bool {
+  self.compare(other) > 0
+}
+
+///|
+/// Return the earlier of this DateTime and `other`.
+pub fn DateTime::min(self : DateTime, other : DateTime) -> DateTime {
+  if self.compare(other) <= 0 {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+/// Return the later of this DateTime and `other`.
+pub fn DateTime::max(self : DateTime, other : DateTime) -> DateTime {
+  if self.compare(other) >= 0 {
+    self
+  } else {
+    other
+  }
+}
+
+///|
+/// Clamp this DateTime to the inclusive range `[lo, hi]`. Assumes `lo <= hi`.
+pub fn DateTime::clamp(
+  self : DateTime,
+  lo : DateTime,
+  hi : DateTime,
+) -> DateTime {
+  if self.compare(lo) < 0 {
+    lo
+  } else if self.compare(hi) > 0 {
+    hi
+  } else {
+    self
+  }
+}
+
+///|
+/// Wall-clock duration elapsed since `earlier` (`self - earlier`).
+pub fn DateTime::since(self : DateTime, earlier : DateTime) -> Duration {
+  self.diff(earlier)
+}
+
+///|
+/// Wall-clock duration until `later` (`later - self`).
+pub fn DateTime::until(self : DateTime, later : DateTime) -> Duration {
+  later.diff(self)
 }
 
 // ─── Formatting ───────────────────────────────────────────────────────────────

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -430,6 +430,22 @@ test "Date::days_until" {
 }
 
 ///|
+test "Date comparison helpers" {
+  let jan = @tempo.Date::new(2024, 1, 1)
+  let feb = @tempo.Date::new(2024, 2, 1)
+  let mar = @tempo.Date::new(2024, 3, 1)
+  assert_eq(jan.is_before(feb), true)
+  assert_eq(feb.is_before(jan), false)
+  assert_eq(feb.is_after(jan), true)
+  assert_eq(jan.is_after(feb), false)
+  assert_eq(mar.min(jan), jan)
+  assert_eq(jan.max(mar), mar)
+  assert_eq(jan.clamp(feb, mar), feb)
+  assert_eq(feb.clamp(jan, mar), feb)
+  assert_eq(mar.add_days(1).clamp(jan, mar), mar)
+}
+
+///|
 test "Date::parse valid" {
   let d = @tempo.Date::parse("2024-03-15")
   assert_eq(d.year, 2024)
@@ -485,6 +501,22 @@ test "Time::with field updaters reject invalid times" {
     (try? @tempo.Time::new(12, 34, 56, 789).with_nanosecond(1_000_000_000))
     is Err(_),
   )
+}
+
+///|
+test "Time comparison helpers" {
+  let early = @tempo.Time::new(8, 0, 0, 0)
+  let mid = @tempo.Time::new(12, 0, 0, 0)
+  let late = @tempo.Time::new(17, 0, 0, 0)
+  assert_eq(early.is_before(mid), true)
+  assert_eq(mid.is_before(early), false)
+  assert_eq(mid.is_after(early), true)
+  assert_eq(early.is_after(mid), false)
+  assert_eq(late.min(early), early)
+  assert_eq(early.max(late), late)
+  assert_eq(early.clamp(mid, late), mid)
+  assert_eq(mid.clamp(early, late), mid)
+  assert_eq(late.clamp(early, mid), mid)
 }
 
 ///|
@@ -1121,6 +1153,25 @@ test "DateTime compare" {
   assert_eq(a < b, true)
   assert_eq(b > a, true)
   assert_eq(a == a, true)
+}
+
+///|
+test "DateTime comparison helpers and elapsed wrappers" {
+  let dt = @tempo.DateTime::parse("2024-03-15T12:00:00Z")
+  let dt2 = dt.add(@tempo.Duration::hours(2L))
+  let dt3 = dt.add(@tempo.Duration::hours(3L))
+  assert_eq(dt.is_before(dt2), true)
+  assert_eq(dt2.is_before(dt), false)
+  assert_eq(dt2.is_after(dt), true)
+  assert_eq(dt.is_after(dt2), false)
+  assert_eq(dt3.min(dt), dt)
+  assert_eq(dt.max(dt3), dt3)
+  assert_eq(dt.clamp(dt2, dt3), dt2)
+  assert_eq(dt2.clamp(dt, dt3), dt2)
+  assert_eq(dt3.clamp(dt, dt2), dt2)
+  assert_eq(dt2.since(dt).as_hours(), 2L)
+  assert_eq(dt.until(dt2).as_hours(), 2L)
+  assert_eq(dt.since(dt2).as_hours(), -2L)
 }
 
 ///|


### PR DESCRIPTION
Closes tempo-5nc.4.

Adds Date/Time/DateTime comparison helper methods over the existing derived Compare, including min/max/clamp with the documented lo <= hi assumption.

Adds DateTime since/until wrappers over diff and blackbox coverage for comparison truthiness, min/max, clamp, and elapsed sign direction.

Verification:
- moon info && moon fmt
- moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: 13aa6476fdd02c2d37dcaa63aa19d50dc89fc9ab
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: 13aa6476fdd02c2d37dcaa63aa19d50dc89fc9ab
  - output tail:
```text
Total tests: 193, passed: 193, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: 13aa6476fdd02c2d37dcaa63aa19d50dc89fc9ab
  - output tail:
```text
Total tests: 193, passed: 193, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: 13aa6476fdd02c2d37dcaa63aa19d50dc89fc9ab
  - output tail:
```text
Total tests: 193, passed: 193, failed: 0.
```