### PR TITLE
Add first-class interval types

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -43,6 +43,15 @@ pub fn Date::with_month(Self, Int) -> Self raise TempoError
 pub fn Date::with_year(Self, Int) -> Self raise TempoError
 pub impl Show for Date
 
+pub(all) struct DateInterval {
+  start : Date
+  end : Date
+} derive(Eq)
+pub fn DateInterval::contains(Self, Date) -> Bool
+pub fn DateInterval::intersection(Self, Self) -> Self?
+pub fn DateInterval::length_in_days(Self) -> Int
+pub fn DateInterval::overlaps(Self, Self) -> Bool
+
 pub struct DateTime {
   date : Date
   time : Time
@@ -121,6 +130,15 @@ pub impl Add for Duration
 pub impl Neg for Duration
 pub impl Show for Duration
 pub impl Sub for Duration
+
+pub(all) struct Interval {
+  start : DateTime
+  end : DateTime
+} derive(Eq)
+pub fn Interval::contains(Self, DateTime) -> Bool
+pub fn Interval::intersection(Self, Self) -> Self?
+pub fn Interval::overlaps(Self, Self) -> Bool
+pub fn Interval::to_duration(Self) -> Duration
 
 pub(all) enum Month {
   January

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -26,6 +26,18 @@ pub struct Date {
 } derive(Eq, Compare)
 
 ///|
+/// A calendar date interval with an inclusive end date: `[start, end]`.
+///
+/// This mirrors NodaTime's DateInterval-vs-Interval convention split:
+/// DateInterval is inclusive-end for whole calendar dates, while `Interval` is
+/// half-open for instants. Assumes `start <= end`; methods do not validate
+/// inverted intervals.
+pub(all) struct DateInterval {
+  start : Date
+  end : Date
+} derive(Eq)
+
+///|
 /// ISO 8601 weekday, ordered Monday through Sunday.
 pub(all) enum Weekday {
   Monday
@@ -279,6 +291,18 @@ pub struct DateTime {
   date : Date
   time : Time
 } derive(Eq, Compare)
+
+///|
+/// A DateTime interval with a half-open end instant: `[start, end)`.
+///
+/// This mirrors NodaTime's DateInterval-vs-Interval convention split:
+/// `DateInterval` is inclusive-end for calendar dates, while Interval is
+/// half-open for instants. Assumes `start <= end`; methods do not validate
+/// inverted intervals.
+pub(all) struct Interval {
+  start : DateTime
+  end : DateTime
+} derive(Eq)
 
 ///|
 /// A signed duration stored as total nanoseconds.
@@ -551,6 +575,45 @@ pub fn Date::clamp(self : Date, lo : Date, hi : Date) -> Date {
   } else {
     self
   }
+}
+
+// ─── DateInterval helpers ────────────────────────────────────────────────────
+
+///|
+/// `true` if `d` is in this inclusive-end date interval `[start, end]`.
+pub fn DateInterval::contains(self : DateInterval, d : Date) -> Bool {
+  self.start <= d && d <= self.end
+}
+
+///|
+/// `true` if this inclusive-end date interval shares at least one date with
+/// `other`.
+pub fn DateInterval::overlaps(
+  self : DateInterval,
+  other : DateInterval,
+) -> Bool {
+  self.start <= other.end && other.start <= self.end
+}
+
+///|
+/// Return the inclusive-end overlap between this date interval and `other`.
+pub fn DateInterval::intersection(
+  self : DateInterval,
+  other : DateInterval,
+) -> DateInterval? {
+  let s = self.start.max(other.start)
+  let e = self.end.min(other.end)
+  if s <= e {
+    Some({ start: s, end: e })
+  } else {
+    None
+  }
+}
+
+///|
+/// Inclusive day count for this date interval.
+pub fn DateInterval::length_in_days(self : DateInterval) -> Int {
+  self.start.days_until(self.end) + 1
 }
 
 ///|
@@ -1214,6 +1277,39 @@ pub fn DateTime::clamp(
   } else {
     self
   }
+}
+
+// ─── Interval helpers ────────────────────────────────────────────────────────
+
+///|
+/// `true` if `dt` is in this half-open DateTime interval `[start, end)`.
+pub fn Interval::contains(self : Interval, dt : DateTime) -> Bool {
+  self.start <= dt && dt < self.end
+}
+
+///|
+/// `true` if this half-open DateTime interval shares at least one instant with
+/// `other`.
+pub fn Interval::overlaps(self : Interval, other : Interval) -> Bool {
+  self.start < other.end && other.start < self.end
+}
+
+///|
+/// Return the half-open overlap between this DateTime interval and `other`.
+pub fn Interval::intersection(self : Interval, other : Interval) -> Interval? {
+  let s = self.start.max(other.start)
+  let e = self.end.min(other.end)
+  if s < e {
+    Some({ start: s, end: e })
+  } else {
+    None
+  }
+}
+
+///|
+/// Duration of this half-open DateTime interval (`end - start`).
+pub fn Interval::to_duration(self : Interval) -> Duration {
+  self.end.diff(self.start)
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -1569,3 +1569,148 @@ test "Date::parse roundtrip 2-digit year" {
   let d = @tempo.Date::new(50, 3, 5)
   assert_eq(d.format(), "0050-03-05")
 }
+
+///|
+fn date_interval(start : @tempo.Date, end : @tempo.Date) -> @tempo.DateInterval {
+  { start, end }
+}
+
+///|
+fn interval(start : @tempo.DateTime, end : @tempo.DateTime) -> @tempo.Interval {
+  { start, end }
+}
+
+///|
+test "DateInterval::contains includes both date boundaries" {
+  let start = @tempo.Date::new(2024, 1, 1)
+  let end = @tempo.Date::new(2024, 1, 10)
+  let range = date_interval(start, end)
+  assert_eq(range.contains(start), true)
+  assert_eq(range.contains(end), true)
+  assert_eq(range.contains(@tempo.Date::new(2023, 12, 31)), false)
+  assert_eq(range.contains(@tempo.Date::new(2024, 1, 11)), false)
+}
+
+///|
+test "DateInterval::overlaps includes touching inclusive ends" {
+  let range = date_interval(
+    @tempo.Date::new(2024, 1, 1),
+    @tempo.Date::new(2024, 1, 10),
+  )
+  let touching = date_interval(
+    @tempo.Date::new(2024, 1, 10),
+    @tempo.Date::new(2024, 1, 12),
+  )
+  let inside = date_interval(
+    @tempo.Date::new(2024, 1, 3),
+    @tempo.Date::new(2024, 1, 4),
+  )
+  let disjoint = date_interval(
+    @tempo.Date::new(2024, 1, 11),
+    @tempo.Date::new(2024, 1, 12),
+  )
+  assert_eq(range.overlaps(touching), true)
+  assert_eq(range.overlaps(inside), true)
+  assert_eq(range.overlaps(disjoint), false)
+}
+
+///|
+test "DateInterval::intersection uses inclusive bounds" {
+  let range = date_interval(
+    @tempo.Date::new(2024, 1, 1),
+    @tempo.Date::new(2024, 1, 10),
+  )
+  let overlapping = date_interval(
+    @tempo.Date::new(2024, 1, 5),
+    @tempo.Date::new(2024, 1, 12),
+  )
+  let touching = date_interval(
+    @tempo.Date::new(2024, 1, 10),
+    @tempo.Date::new(2024, 1, 12),
+  )
+  let disjoint = date_interval(
+    @tempo.Date::new(2024, 1, 11),
+    @tempo.Date::new(2024, 1, 12),
+  )
+  assert_true(
+    range.intersection(overlapping) ==
+    Some(
+      date_interval(@tempo.Date::new(2024, 1, 5), @tempo.Date::new(2024, 1, 10)),
+    ),
+  )
+  assert_true(
+    range.intersection(touching) ==
+    Some(
+      date_interval(
+        @tempo.Date::new(2024, 1, 10),
+        @tempo.Date::new(2024, 1, 10),
+      ),
+    ),
+  )
+  assert_true(range.intersection(disjoint) is None)
+}
+
+///|
+test "DateInterval::length_in_days is inclusive" {
+  let ten_days = date_interval(
+    @tempo.Date::new(2024, 1, 1),
+    @tempo.Date::new(2024, 1, 10),
+  )
+  let one_day = date_interval(
+    @tempo.Date::new(2024, 1, 10),
+    @tempo.Date::new(2024, 1, 10),
+  )
+  assert_eq(ten_days.length_in_days(), 10)
+  assert_eq(one_day.length_in_days(), 1)
+}
+
+///|
+test "Interval::contains includes start and excludes end" {
+  let start = @tempo.DateTime::parse("2024-01-01T00:00:00Z")
+  let end = start.add(@tempo.Duration::hours(2L))
+  let range = interval(start, end)
+  assert_eq(range.contains(start), true)
+  assert_eq(range.contains(start.add(@tempo.Duration::hours(1L))), true)
+  assert_eq(range.contains(end), false)
+  assert_eq(range.contains(start.sub(@tempo.Duration::nanoseconds(1L))), false)
+}
+
+///|
+test "Interval::overlaps treats touching half-open bounds as disjoint" {
+  let start = @tempo.DateTime::parse("2024-01-01T00:00:00Z")
+  let end = start.add(@tempo.Duration::hours(2L))
+  let range = interval(start, end)
+  let overlapping = interval(
+    start.add(@tempo.Duration::hours(1L)),
+    start.add(@tempo.Duration::hours(3L)),
+  )
+  let touching_after = interval(end, end.add(@tempo.Duration::hours(1L)))
+  let touching_before = interval(start.sub(@tempo.Duration::hours(1L)), start)
+  assert_eq(range.overlaps(overlapping), true)
+  assert_eq(range.overlaps(touching_after), false)
+  assert_eq(range.overlaps(touching_before), false)
+}
+
+///|
+test "Interval::intersection uses half-open bounds" {
+  let start = @tempo.DateTime::parse("2024-01-01T00:00:00Z")
+  let end = start.add(@tempo.Duration::hours(2L))
+  let range = interval(start, end)
+  let overlapping = interval(
+    start.add(@tempo.Duration::hours(1L)),
+    start.add(@tempo.Duration::hours(3L)),
+  )
+  let touching = interval(end, end.add(@tempo.Duration::hours(1L)))
+  assert_true(
+    range.intersection(overlapping) ==
+    Some(interval(start.add(@tempo.Duration::hours(1L)), end)),
+  )
+  assert_true(range.intersection(touching) is None)
+}
+
+///|
+test "Interval::to_duration returns end minus start" {
+  let start = @tempo.DateTime::parse("2024-01-01T00:00:00Z")
+  let range = interval(start, start.add(@tempo.Duration::hours(2L)))
+  assert_eq(range.to_duration(), @tempo.Duration::hours(2L))
+}

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -1586,6 +1586,7 @@ test "DateInterval::contains includes both date boundaries" {
   let end = @tempo.Date::new(2024, 1, 10)
   let range = date_interval(start, end)
   assert_eq(range.contains(start), true)
+  assert_eq(range.contains(@tempo.Date::new(2024, 1, 5)), true)
   assert_eq(range.contains(end), true)
   assert_eq(range.contains(@tempo.Date::new(2023, 12, 31)), false)
   assert_eq(range.contains(@tempo.Date::new(2024, 1, 11)), false)
@@ -1610,6 +1611,7 @@ test "DateInterval::overlaps includes touching inclusive ends" {
     @tempo.Date::new(2024, 1, 12),
   )
   assert_eq(range.overlaps(touching), true)
+  assert_eq(touching.overlaps(range), true)
   assert_eq(range.overlaps(inside), true)
   assert_eq(range.overlaps(disjoint), false)
 }
@@ -1632,6 +1634,14 @@ test "DateInterval::intersection uses inclusive bounds" {
     @tempo.Date::new(2024, 1, 11),
     @tempo.Date::new(2024, 1, 12),
   )
+  let gap_a = date_interval(
+    @tempo.Date::new(2024, 1, 1),
+    @tempo.Date::new(2024, 1, 5),
+  )
+  let gap_b = date_interval(
+    @tempo.Date::new(2024, 1, 10),
+    @tempo.Date::new(2024, 1, 15),
+  )
   assert_true(
     range.intersection(overlapping) ==
     Some(
@@ -1648,6 +1658,7 @@ test "DateInterval::intersection uses inclusive bounds" {
     ),
   )
   assert_true(range.intersection(disjoint) is None)
+  assert_true(gap_a.intersection(gap_b) is None)
 }
 
 ///|
@@ -1668,9 +1679,11 @@ test "DateInterval::length_in_days is inclusive" {
 test "Interval::contains includes start and excludes end" {
   let start = @tempo.DateTime::parse("2024-01-01T00:00:00Z")
   let end = start.add(@tempo.Duration::hours(2L))
+  let end_minus_one_ns = end.sub(@tempo.Duration::nanoseconds(1L))
   let range = interval(start, end)
   assert_eq(range.contains(start), true)
   assert_eq(range.contains(start.add(@tempo.Duration::hours(1L))), true)
+  assert_eq(range.contains(end_minus_one_ns), true)
   assert_eq(range.contains(end), false)
   assert_eq(range.contains(start.sub(@tempo.Duration::nanoseconds(1L))), false)
 }
@@ -1688,6 +1701,7 @@ test "Interval::overlaps treats touching half-open bounds as disjoint" {
   let touching_before = interval(start.sub(@tempo.Duration::hours(1L)), start)
   assert_eq(range.overlaps(overlapping), true)
   assert_eq(range.overlaps(touching_after), false)
+  assert_eq(touching_after.overlaps(range), false)
   assert_eq(range.overlaps(touching_before), false)
 }
 
@@ -1701,11 +1715,16 @@ test "Interval::intersection uses half-open bounds" {
     start.add(@tempo.Duration::hours(3L)),
   )
   let touching = interval(end, end.add(@tempo.Duration::hours(1L)))
+  let gap = interval(
+    end.add(@tempo.Duration::hours(1L)),
+    end.add(@tempo.Duration::hours(2L)),
+  )
   assert_true(
     range.intersection(overlapping) ==
     Some(interval(start.add(@tempo.Duration::hours(1L)), end)),
   )
   assert_true(range.intersection(touching) is None)
+  assert_true(range.intersection(gap) is None)
 }
 
 ///|


### PR DESCRIPTION
Closes tempo-5nc.5.

Adds DateInterval for inclusive-end calendar date ranges and Interval for half-open DateTime ranges, with contains, overlaps, intersection, and duration/length helpers. Updates blackbox tests across the boundary cases and regenerates the MoonBit interface.

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: e78ff46add3b29c4fc98a181f4cf2f3940aa1587
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: e78ff46add3b29c4fc98a181f4cf2f3940aa1587
  - output tail:
```text
Total tests: 201, passed: 201, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: e78ff46add3b29c4fc98a181f4cf2f3940aa1587
  - output tail:
```text
Total tests: 201, passed: 201, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: e78ff46add3b29c4fc98a181f4cf2f3940aa1587
  - output tail:
```text
Total tests: 201, passed: 201, failed: 0.
```