### PR TITLE
Add DateTime unit rounding

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -75,6 +75,7 @@ pub fn DateTime::min(Self, Self) -> Self
 pub fn DateTime::new(Date, Time) -> Self
 pub fn DateTime::now() -> Self
 pub fn DateTime::parse(String) -> Self raise TempoError
+pub fn DateTime::round_to(Self, TimeUnit, RoundMode) -> Self
 pub fn DateTime::since(Self, Self) -> Duration
 pub fn DateTime::start_of_day(Self) -> Self
 pub fn DateTime::start_of_month(Self) -> Self
@@ -160,6 +161,13 @@ pub fn Month::next(Self) -> Self
 pub fn Month::previous(Self) -> Self
 pub fn Month::to_int(Self) -> Int
 pub impl Show for Month
+
+pub(all) enum RoundMode {
+  Floor
+  Ceil
+  HalfExpand
+} derive(Compare, Eq, Hash)
+pub impl Show for RoundMode
 
 pub struct Time {
   hour : Int

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -267,7 +267,8 @@ pub struct Time {
 } derive(Eq, Compare)
 
 ///|
-/// Units supported by `DateTime::truncate_to`, ordered smallest to largest.
+/// Units supported by `DateTime::truncate_to` and `DateTime::round_to`, ordered
+/// smallest to largest.
 pub(all) enum TimeUnit {
   Second
   Minute
@@ -282,6 +283,24 @@ pub impl Show for TimeUnit with fn output(self, logger) {
     Minute => logger.write_string("Minute")
     Hour => logger.write_string("Hour")
     Day => logger.write_string("Day")
+  }
+}
+
+///|
+/// Rounding modes for `DateTime::round_to`, ordered from earlier-boundary
+/// preference to nearest-boundary behavior.
+pub(all) enum RoundMode {
+  Floor
+  Ceil
+  HalfExpand
+} derive(Eq, Compare, Hash)
+
+///|
+pub impl Show for RoundMode with fn output(self, logger) {
+  match self {
+    Floor => logger.write_string("Floor")
+    Ceil => logger.write_string("Ceil")
+    HalfExpand => logger.write_string("HalfExpand")
   }
 }
 
@@ -901,6 +920,75 @@ pub fn DateTime::truncate_to(self : DateTime, unit : TimeUnit) -> DateTime {
     Hour =>
       { ..self, time: { ..self.time, minute: 0, second: 0, nanosecond: 0 } }
     Day => self.start_of_day()
+  }
+}
+
+///|
+/// Round this DateTime to the requested unit boundary.
+///
+/// `Floor` is equivalent to `truncate_to(unit)`. `Ceil` rounds to the next
+/// boundary only when there is a remainder. `HalfExpand` rounds to the nearest
+/// boundary, with exact half-unit ties rounded up toward the later boundary.
+///
+/// Rounding is anchored to the calendar day and carries with `Date::add_days`,
+/// avoiding Unix-nanosecond conversion for dates outside the Int64 nanosecond
+/// timestamp range.
+pub fn DateTime::round_to(
+  self : DateTime,
+  unit : TimeUnit,
+  mode : RoundMode,
+) -> DateTime {
+  let floored = self.truncate_to(unit)
+  let t = self.time
+  let unit_ns = match unit {
+    Second => ns_per_sec
+    Minute => ns_per_min
+    Hour => ns_per_hour
+    Day => 86_400L * ns_per_sec
+  }
+  let rem_ns = match unit {
+    Second => t.nanosecond.to_int64()
+    Minute => t.second.to_int64() * ns_per_sec + t.nanosecond.to_int64()
+    Hour =>
+      (t.minute.to_int64() * 60L + t.second.to_int64()) * ns_per_sec +
+      t.nanosecond.to_int64()
+    Day =>
+      (
+        t.hour.to_int64() * 3600L +
+        t.minute.to_int64() * 60L +
+        t.second.to_int64()
+      ) *
+      ns_per_sec +
+      t.nanosecond.to_int64()
+  }
+  let round_up = match mode {
+    Floor => false
+    Ceil => rem_ns > 0L
+    HalfExpand => rem_ns * 2L >= unit_ns
+  }
+  if !round_up {
+    floored
+  } else {
+    let unit_secs = match unit {
+      Second => 1
+      Minute => 60
+      Hour => 3600
+      Day => 86_400
+    }
+    let ft = floored.time
+    let sod = ft.hour * 3600 + ft.minute * 60 + ft.second
+    let total = sod + unit_secs
+    let day_carry = total / 86_400
+    let r = total % 86_400
+    {
+      date: floored.date.add_days(day_carry),
+      time: {
+        hour: r / 3600,
+        minute: r % 3600 / 60,
+        second: r % 60,
+        nanosecond: 0,
+      },
+    }
   }
 }
 

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -243,6 +243,115 @@ test "DateTime truncate_to day is calendar anchored for far future dates" {
 }
 
 ///|
+test "DateTime::round_to hour modes" {
+  assert_eq(
+    @tempo.DateTime::parse("2024-03-15T14:30:00Z")
+    .round_to(@tempo.Hour, @tempo.HalfExpand)
+    .format(),
+    "2024-03-15T15:00:00Z",
+  )
+  assert_eq(
+    @tempo.DateTime::parse("2024-03-15T14:29:59.999999999Z")
+    .round_to(@tempo.Hour, @tempo.HalfExpand)
+    .format(),
+    "2024-03-15T14:00:00Z",
+  )
+  assert_eq(
+    @tempo.DateTime::parse("2024-03-15T14:31:00Z")
+    .round_to(@tempo.Hour, @tempo.HalfExpand)
+    .format(),
+    "2024-03-15T15:00:00Z",
+  )
+  assert_eq(
+    @tempo.DateTime::parse("2024-03-15T14:59:00Z")
+    .round_to(@tempo.Hour, @tempo.Floor)
+    .format(),
+    "2024-03-15T14:00:00Z",
+  )
+  assert_eq(
+    @tempo.DateTime::parse("2024-03-15T14:00:00Z")
+    .round_to(@tempo.Hour, @tempo.Ceil)
+    .format(),
+    "2024-03-15T14:00:00Z",
+  )
+  assert_eq(
+    @tempo.DateTime::parse("2024-03-15T14:01:00Z")
+    .round_to(@tempo.Hour, @tempo.Ceil)
+    .format(),
+    "2024-03-15T15:00:00Z",
+  )
+}
+
+///|
+test "DateTime::round_to minute half expand" {
+  assert_eq(
+    @tempo.DateTime::parse("2024-03-15T14:31:29Z")
+    .round_to(@tempo.Minute, @tempo.HalfExpand)
+    .format(),
+    "2024-03-15T14:31:00Z",
+  )
+  assert_eq(
+    @tempo.DateTime::parse("2024-03-15T14:31:30Z")
+    .round_to(@tempo.Minute, @tempo.HalfExpand)
+    .format(),
+    "2024-03-15T14:32:00Z",
+  )
+}
+
+///|
+test "DateTime::round_to day half expand carries date" {
+  assert_eq(
+    @tempo.DateTime::parse("2024-03-15T11:59:59Z")
+    .round_to(@tempo.Day, @tempo.HalfExpand)
+    .format(),
+    "2024-03-15T00:00:00Z",
+  )
+  assert_eq(
+    @tempo.DateTime::parse("2024-03-15T12:00:00Z")
+    .round_to(@tempo.Day, @tempo.HalfExpand)
+    .format(),
+    "2024-03-16T00:00:00Z",
+  )
+}
+
+///|
+test "DateTime::round_to ceil carries across day and month" {
+  assert_eq(
+    @tempo.DateTime::parse("2024-03-15T23:30:00Z")
+    .round_to(@tempo.Hour, @tempo.Ceil)
+    .format(),
+    "2024-03-16T00:00:00Z",
+  )
+  assert_eq(
+    @tempo.DateTime::parse("2024-02-29T23:30:00Z")
+    .round_to(@tempo.Hour, @tempo.Ceil)
+    .format(),
+    "2024-03-01T00:00:00Z",
+  )
+}
+
+///|
+test "DateTime::round_to far future avoids epoch nanos overflow" {
+  assert_eq(
+    @tempo.DateTime::parse("3000-01-01T14:31:30Z")
+    .round_to(@tempo.Minute, @tempo.HalfExpand)
+    .format(),
+    "3000-01-01T14:32:00Z",
+  )
+  assert_eq(
+    @tempo.DateTime::parse("3000-01-01T23:30:00Z")
+    .round_to(@tempo.Hour, @tempo.Ceil)
+    .format(),
+    "3000-01-02T00:00:00Z",
+  )
+}
+
+///|
+test "RoundMode Show output" {
+  inspect(@tempo.HalfExpand, content="HalfExpand")
+}
+
+///|
 test "DateTime accessors and component updaters" {
   let date = @tempo.Date::new(2024, 3, 15)
   let time = @tempo.Time::new(12, 34, 56, 789)


### PR DESCRIPTION
Closes tempo-5nc.3.

- Adds RoundMode with manual Show and DateTime::round_to for Second/Minute/Hour/Day.
- Keeps rounding field-based with Date::add_days for carries, avoiding epoch nanosecond conversion.
- Adds blackbox coverage for Floor, Ceil, HalfExpand, date/month carry, and year-3000 overflow-safe rounding.

Verified: moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: 3e68ce04b8bdc03e474a1518b3b6063ec9da6e74
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: 3e68ce04b8bdc03e474a1518b3b6063ec9da6e74
  - output tail:
```text
Total tests: 207, passed: 207, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: 3e68ce04b8bdc03e474a1518b3b6063ec9da6e74
  - output tail:
```text
Total tests: 207, passed: 207, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: 3e68ce04b8bdc03e474a1518b3b6063ec9da6e74
  - output tail:
```text
Total tests: 207, passed: 207, failed: 0.
```