### PR TITLE
Add Date weekday navigation primitives

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -34,7 +34,12 @@ pub fn Date::max(Self, Self) -> Self
 pub fn Date::min(Self, Self) -> Self
 pub fn Date::month_enum(Self) -> Month
 pub fn Date::new(Int, Int, Int) -> Self raise TempoError
+pub fn Date::next(Self, Weekday) -> Self
+pub fn Date::next_or_same(Self, Weekday) -> Self
+pub fn Date::nth_weekday_of_month(Int, Int, Weekday, Int) -> Self raise TempoError
 pub fn Date::parse(String) -> Self raise TempoError
+pub fn Date::previous(Self, Weekday) -> Self
+pub fn Date::previous_or_same(Self, Weekday) -> Self
 pub fn Date::start_of_month(Self) -> Self
 pub fn Date::start_of_year(Self) -> Self
 pub fn Date::weekday(Self) -> Weekday

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -527,6 +527,77 @@ pub fn Date::weekday(self : Date) -> Weekday {
 }
 
 ///|
+fn positive_mod7(n : Int) -> Int {
+  (n % 7 + 7) % 7
+}
+
+///|
+/// Nearest date strictly after this date that falls on `wd`.
+pub fn Date::next(self : Date, wd : Weekday) -> Date {
+  let raw = positive_mod7(wd.to_int() - self.weekday().to_int())
+  let delta = if raw == 0 { 7 } else { raw }
+  self.add_days(delta)
+}
+
+///|
+/// Nearest date strictly before this date that falls on `wd`.
+pub fn Date::previous(self : Date, wd : Weekday) -> Date {
+  let raw = positive_mod7(self.weekday().to_int() - wd.to_int())
+  let delta = if raw == 0 { 7 } else { raw }
+  self.add_days(-delta)
+}
+
+///|
+/// This date if it falls on `wd`, otherwise the next such date.
+pub fn Date::next_or_same(self : Date, wd : Weekday) -> Date {
+  let delta = positive_mod7(wd.to_int() - self.weekday().to_int())
+  self.add_days(delta)
+}
+
+///|
+/// This date if it falls on `wd`, otherwise the previous such date.
+pub fn Date::previous_or_same(self : Date, wd : Weekday) -> Date {
+  let delta = positive_mod7(self.weekday().to_int() - wd.to_int())
+  self.add_days(-delta)
+}
+
+///|
+/// The nth occurrence of `wd` in `year`/`month`.
+///
+/// Positive `n` counts from the start of the month; negative `n` counts from
+/// the end, so `n == -1` is the last occurrence.
+pub fn Date::nth_weekday_of_month(
+  year : Int,
+  month : Int,
+  wd : Weekday,
+  n : Int,
+) -> Date raise TempoError {
+  if n == 0 {
+    raise TempoError("weekday occurrence must not be zero")
+  }
+  if n > 0 {
+    let first = Date::new(year, month, 1)
+    let offset = positive_mod7(wd.to_int() - first.weekday().to_int())
+    let day = 1 + offset + 7 * (n - 1)
+    if day > days_in_month(year, month) {
+      raise TempoError("weekday occurrence does not exist in month")
+    } else {
+      Date::new(year, month, day)
+    }
+  } else {
+    let last_day = days_in_month(year, month)
+    let last = Date::new(year, month, last_day)
+    let back = positive_mod7(last.weekday().to_int() - wd.to_int())
+    let day = last_day - back + 7 * (n + 1)
+    if day < 1 {
+      raise TempoError("weekday occurrence does not exist in month")
+    } else {
+      Date::new(year, month, day)
+    }
+  }
+}
+
+///|
 /// Calendar month for this date.
 pub fn Date::month_enum(self : Date) -> Month {
   match Month::from_int(self.month) {

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -578,21 +578,25 @@ pub fn Date::nth_weekday_of_month(
   if n > 0 {
     let first = Date::new(year, month, 1)
     let offset = positive_mod7(wd.to_int() - first.weekday().to_int())
-    let day = 1 + offset + 7 * (n - 1)
-    if day > days_in_month(year, month) {
+    let first_match_day = 1 + offset
+    let day = first_match_day.to_int64() + 7L * (n.to_int64() - 1L)
+    let max_day = days_in_month(year, month).to_int64()
+    if day < 1L || day > max_day {
       raise TempoError("weekday occurrence does not exist in month")
     } else {
-      Date::new(year, month, day)
+      Date::new(year, month, day.to_int())
     }
   } else {
     let last_day = days_in_month(year, month)
     let last = Date::new(year, month, last_day)
     let back = positive_mod7(last.weekday().to_int() - wd.to_int())
-    let day = last_day - back + 7 * (n + 1)
-    if day < 1 {
+    let last_match_day = last_day - back
+    let day = last_match_day.to_int64() + 7L * (n.to_int64() + 1L)
+    let max_day = last_day.to_int64()
+    if day < 1L || day > max_day {
       raise TempoError("weekday occurrence does not exist in month")
     } else {
-      Date::new(year, month, day)
+      Date::new(year, month, day.to_int())
     }
   }
 }

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -522,6 +522,56 @@ test "Date typed weekday and month accessors" {
 }
 
 ///|
+test "Date weekday navigation is strictly next and previous" {
+  let d = @tempo.Date::new(2024, 3, 15)
+  assert_eq(d.next(@tempo.Monday), @tempo.Date::new(2024, 3, 18))
+  assert_eq(d.next(@tempo.Friday), @tempo.Date::new(2024, 3, 22))
+  assert_eq(d.previous(@tempo.Monday), @tempo.Date::new(2024, 3, 11))
+  assert_eq(d.previous(@tempo.Friday), @tempo.Date::new(2024, 3, 8))
+}
+
+///|
+test "Date weekday navigation or_same variants allow identity" {
+  let d = @tempo.Date::new(2024, 3, 15)
+  assert_eq(d.next_or_same(@tempo.Friday), d)
+  assert_eq(d.next_or_same(@tempo.Monday), @tempo.Date::new(2024, 3, 18))
+  assert_eq(d.previous_or_same(@tempo.Friday), d)
+  assert_eq(d.previous_or_same(@tempo.Monday), @tempo.Date::new(2024, 3, 11))
+}
+
+///|
+test "Date weekday navigation crosses year boundary" {
+  assert_eq(
+    @tempo.Date::new(2024, 12, 30).next(@tempo.Monday),
+    @tempo.Date::new(2025, 1, 6),
+  )
+}
+
+///|
+test "Date::nth_weekday_of_month finds weekdays from either end" {
+  assert_eq(
+    @tempo.Date::nth_weekday_of_month(2024, 3, @tempo.Tuesday, 3),
+    @tempo.Date::new(2024, 3, 19),
+  )
+  assert_eq(
+    @tempo.Date::nth_weekday_of_month(2024, 3, @tempo.Friday, -1),
+    @tempo.Date::new(2024, 3, 29),
+  )
+}
+
+///|
+test "Date::nth_weekday_of_month rejects missing or zero occurrences" {
+  assert_true(
+    (try? @tempo.Date::nth_weekday_of_month(2024, 3, @tempo.Monday, 5))
+    is Err(_),
+  )
+  assert_true(
+    (try? @tempo.Date::nth_weekday_of_month(2024, 3, @tempo.Tuesday, 0))
+    is Err(_),
+  )
+}
+
+///|
 test "Date::day_of_year" {
   assert_eq(@tempo.Date::new(2024, 1, 1).day_of_year(), 1)
   assert_eq(@tempo.Date::new(2024, 3, 15).day_of_year(), 75)

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -569,6 +569,19 @@ test "Date::nth_weekday_of_month rejects missing or zero occurrences" {
     (try? @tempo.Date::nth_weekday_of_month(2024, 3, @tempo.Tuesday, 0))
     is Err(_),
   )
+  assert_true(
+    (try? @tempo.Date::nth_weekday_of_month(2024, 3, @tempo.Monday, 613_566_758))
+    is Err(_),
+  )
+  assert_true(
+    (try? @tempo.Date::nth_weekday_of_month(
+      2024,
+      3,
+      @tempo.Monday,
+      -613_566_757,
+    ))
+    is Err(_),
+  )
 }
 
 ///|


### PR DESCRIPTION
Closes tempo-4vp.3.\n\nAdds Date weekday scheduling helpers for strict next/previous, next_or_same/previous_or_same, and nth_weekday_of_month with positive and negative occurrence counts.\n\nVerification:\n- moon fmt --check\n- moon test --target wasm-gc\n- moon test --target js\n- moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: f86c7397778b6ed9e150dfedca0102a5b3f86502
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: f86c7397778b6ed9e150dfedca0102a5b3f86502
  - output tail:
```text
Total tests: 212, passed: 212, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: f86c7397778b6ed9e150dfedca0102a5b3f86502
  - output tail:
```text
Total tests: 212, passed: 212, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: f86c7397778b6ed9e150dfedca0102a5b3f86502
  - output tail:
```text
Total tests: 212, passed: 212, failed: 0.
```