### PR TITLE
Add checked Unix nanos conversion

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -76,7 +76,9 @@ pub fn DateTime::from_unix_seconds(Int64) -> Self
 pub fn DateTime::is_after(Self, Self) -> Bool
 pub fn DateTime::is_before(Self, Self) -> Bool
 pub fn DateTime::max(Self, Self) -> Self
+pub fn DateTime::max_unix_nanos() -> Int64
 pub fn DateTime::min(Self, Self) -> Self
+pub fn DateTime::min_unix_nanos() -> Int64
 pub fn DateTime::new(Date, Time) -> Self
 pub fn DateTime::now() -> Self
 pub fn DateTime::parse(String) -> Self raise TempoError
@@ -91,6 +93,7 @@ pub fn DateTime::to_time(Self) -> Time
 pub fn DateTime::to_unix_micros(Self) -> Int64
 pub fn DateTime::to_unix_millis(Self) -> Int64
 pub fn DateTime::to_unix_nanos(Self) -> Int64
+pub fn DateTime::to_unix_nanos_checked(Self) -> Int64?
 pub fn DateTime::to_unix_seconds(Self) -> Int64
 pub fn DateTime::truncate_to(Self, TimeUnit) -> Self
 pub fn DateTime::until(Self, Self) -> Duration

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -1127,11 +1127,59 @@ pub fn DateTime::to_unix_seconds(self : DateTime) -> Int64 {
 ///|
 /// Convert this `DateTime` to a Unix timestamp in nanoseconds.
 ///
-/// **Note:** Int64 can represent ±292 years of nanoseconds from epoch, so
-/// dates outside ~1678–2262 CE will overflow. For wider ranges use
-/// `to_unix_seconds` instead.
+/// **Overflow note:** this method silently wraps on `Int64` overflow. Use
+/// `to_unix_nanos_checked` when dates outside the representable nanosecond
+/// range should return `None`; use `to_unix_seconds` for wider ranges.
 pub fn DateTime::to_unix_nanos(self : DateTime) -> Int64 {
   self.to_unix_seconds() * 1_000_000_000L + self.time.nanosecond.to_int64()
+}
+
+///|
+/// Minimum Unix timestamp in nanoseconds representable by an `Int64`.
+pub fn DateTime::min_unix_nanos() -> Int64 {
+  int64_min_value
+}
+
+///|
+/// Maximum Unix timestamp in nanoseconds representable by an `Int64`.
+pub fn DateTime::max_unix_nanos() -> Int64 {
+  int64_max_value
+}
+
+///|
+/// Convert this `DateTime` to a Unix timestamp in nanoseconds.
+///
+/// Returns `None` when the instant is outside the representable `Int64`
+/// nanosecond range.
+pub fn DateTime::to_unix_nanos_checked(self : DateTime) -> Int64? {
+  let sec = self.to_unix_seconds()
+  let ns = self.time.nanosecond.to_int64()
+  let min_sec = floor_div64(int64_min_value, ns_per_sec)
+  let min_ns_remainder = int64_min_value % ns_per_sec
+  let min_ns = if min_ns_remainder < 0L {
+    min_ns_remainder + ns_per_sec
+  } else {
+    min_ns_remainder
+  }
+  let max_sec = int64_max_value / ns_per_sec
+  let max_ns = int64_max_value % ns_per_sec
+  if sec < min_sec ||
+    sec > max_sec ||
+    (sec == min_sec && ns < min_ns) ||
+    (sec == max_sec && ns > max_ns) {
+    None
+  } else if sec == min_sec {
+    Some(int64_min_value + (ns - min_ns))
+  } else {
+    let prod = sec * ns_per_sec
+    if sec != 0L && prod / ns_per_sec != sec {
+      None
+    } else if prod > int64_max_value - ns {
+      None
+    } else {
+      Some(prod + ns)
+    }
+  }
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -824,6 +824,38 @@ test "to_unix_nanos_checked accepts min representable instant" {
 }
 
 ///|
+test "to_unix_nanos_checked agrees with wrapping conversion at bounds" {
+  let max = @tempo.DateTime::max_unix_nanos()
+  let max_dt = @tempo.DateTime::from_unix_nanos(max)
+  assert_true(max_dt.to_unix_nanos_checked() == Some(max))
+  assert_eq(max_dt.to_unix_nanos(), max)
+  let min = @tempo.DateTime::min_unix_nanos()
+  let min_dt = @tempo.DateTime::from_unix_nanos(min)
+  assert_true(min_dt.to_unix_nanos_checked() == Some(min))
+  assert_eq(min_dt.to_unix_nanos(), min)
+}
+
+///|
+test "to_unix_nanos_checked rejects instants just outside bounds" {
+  assert_true(
+    @tempo.DateTime::parse("2262-04-11T23:47:16.854775808Z").to_unix_nanos_checked()
+    is None,
+  )
+  assert_true(
+    @tempo.DateTime::parse("2262-04-11T23:47:17Z").to_unix_nanos_checked()
+    is None,
+  )
+  assert_true(
+    @tempo.DateTime::parse("1677-09-21T00:12:43.145224191Z").to_unix_nanos_checked()
+    is None,
+  )
+  assert_true(
+    @tempo.DateTime::parse("1677-09-21T00:12:42.145224192Z").to_unix_nanos_checked()
+    is None,
+  )
+}
+
+///|
 test "DateTime Unix nanos representable bounds" {
   assert_eq(@tempo.DateTime::min_unix_nanos(), -9_223_372_036_854_775_808L)
   assert_eq(@tempo.DateTime::max_unix_nanos(), 9_223_372_036_854_775_807L)

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -788,6 +788,48 @@ test "to_unix_nanos roundtrip" {
 }
 
 ///|
+test "to_unix_nanos_checked epoch" {
+  assert_true(@tempo.DateTime::epoch().to_unix_nanos_checked() == Some(0L))
+}
+
+///|
+test "to_unix_nanos_checked in-range matches wrapping conversion" {
+  let dt = @tempo.DateTime::parse("2024-03-15T12:34:56.123456789Z")
+  assert_true(dt.to_unix_nanos_checked() == Some(dt.to_unix_nanos()))
+}
+
+///|
+test "to_unix_nanos_checked rejects far future and far past" {
+  assert_true(
+    @tempo.DateTime::parse("3000-01-01T00:00:00Z").to_unix_nanos_checked()
+    is None,
+  )
+  assert_true(
+    @tempo.DateTime::parse("1000-01-01T00:00:00Z").to_unix_nanos_checked()
+    is None,
+  )
+}
+
+///|
+test "to_unix_nanos_checked accepts max representable instant" {
+  let dt = @tempo.DateTime::parse("2262-04-11T23:47:16.854775807Z")
+  assert_true(dt.to_unix_nanos_checked() == Some(9_223_372_036_854_775_807L))
+}
+
+///|
+test "to_unix_nanos_checked accepts min representable instant" {
+  let min = @tempo.DateTime::min_unix_nanos()
+  let dt = @tempo.DateTime::from_unix_nanos(min)
+  assert_true(dt.to_unix_nanos_checked() == Some(min))
+}
+
+///|
+test "DateTime Unix nanos representable bounds" {
+  assert_eq(@tempo.DateTime::min_unix_nanos(), -9_223_372_036_854_775_808L)
+  assert_eq(@tempo.DateTime::max_unix_nanos(), 9_223_372_036_854_775_807L)
+}
+
+///|
 test "from_unix_millis epoch" {
   assert_eq(@tempo.DateTime::from_unix_millis(0L), @tempo.DateTime::epoch())
   assert_eq(@tempo.DateTime::epoch().to_unix_millis(), 0L)


### PR DESCRIPTION
Closes tempo-4h4.3 and tempo-4h4.4.

What this PR does:
- Adds DateTime::min_unix_nanos() and DateTime::max_unix_nanos() for the Int64 nanosecond bounds.
- Adds DateTime::to_unix_nanos_checked() returning None outside the representable Unix-nanosecond range.
- Updates DateTime::to_unix_nanos() docs to prominently call out silent overflow and point to the checked variant.
- Covers epoch, normal in-range, far-future/far-past rejection, max/min boundary behavior, and Int64 bound constants.

Verification:
- moon fmt --check
- moon test --target wasm-gc
- moon test --target js
- moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: 9f6ac4cdd9be0c81890e49a452abf6c174696b5f
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: 9f6ac4cdd9be0c81890e49a452abf6c174696b5f
  - output tail:
```text
Total tests: 218, passed: 218, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: 9f6ac4cdd9be0c81890e49a452abf6c174696b5f
  - output tail:
```text
Total tests: 218, passed: 218, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: 9f6ac4cdd9be0c81890e49a452abf6c174696b5f
  - output tail:
```text
Total tests: 218, passed: 218, failed: 0.
```