### PR TITLE
Add checked Int64 arithmetic variants

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -62,6 +62,9 @@ pub struct DateTime {
   time : Time
 } derive(Compare, Eq)
 pub fn DateTime::add(Self, Duration) -> Self
+pub fn DateTime::checked_add(Self, Duration) -> Self?
+pub fn DateTime::checked_diff(Self, Self) -> Duration?
+pub fn DateTime::checked_sub(Self, Duration) -> Self?
 pub fn DateTime::clamp(Self, Self, Self) -> Self
 pub fn DateTime::diff(Self, Self) -> Duration
 pub fn DateTime::end_of_day(Self) -> Self
@@ -120,7 +123,9 @@ pub fn Duration::as_minutes(Self) -> Int64
 pub fn Duration::as_nanoseconds(Self) -> Int64
 pub fn Duration::as_seconds(Self) -> Int64
 pub fn Duration::as_weeks(Self) -> Int64
+pub fn Duration::checked_add(Self, Self) -> Self?
 pub fn Duration::checked_multiply(Self, Int64) -> Self?
+pub fn Duration::checked_sub(Self, Self) -> Self?
 pub fn Duration::days(Int64) -> Self
 pub fn Duration::divide(Self, Int64) -> Self raise TempoError
 pub fn Duration::hours(Int64) -> Self

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -1219,6 +1219,24 @@ let int64_min_value : Int64 = -9_223_372_036_854_775_808L
 let int64_max_value : Int64 = 9_223_372_036_854_775_807L
 
 ///|
+fn checked_i64_add(a : Int64, b : Int64) -> Int64? {
+  if (b > 0L && a > int64_max_value - b) || (b < 0L && a < int64_min_value - b) {
+    None
+  } else {
+    Some(a + b)
+  }
+}
+
+///|
+fn checked_i64_sub(a : Int64, b : Int64) -> Int64? {
+  if (b < 0L && a > int64_max_value + b) || (b > 0L && a < int64_min_value + b) {
+    None
+  } else {
+    Some(a - b)
+  }
+}
+
+///|
 /// Create a Duration from a number of nanoseconds.
 pub fn Duration::nanoseconds(ns : Int64) -> Duration {
   { nanoseconds: ns }
@@ -1408,13 +1426,39 @@ pub fn Duration::divide(
 }
 
 ///|
+/// Add two durations.
+///
+/// This wraps on `Int64` overflow. Use `checked_add` when overflow should
+/// return `None`.
 pub impl Add for Duration with fn add(self, other : Duration) -> Duration {
   { nanoseconds: self.nanoseconds + other.nanoseconds }
 }
 
 ///|
+/// Subtract one duration from another.
+///
+/// This wraps on `Int64` overflow. Use `checked_sub` when overflow should
+/// return `None`.
 pub impl Sub for Duration with fn sub(self, other : Duration) -> Duration {
   { nanoseconds: self.nanoseconds - other.nanoseconds }
+}
+
+///|
+/// Add two durations, returning `None` on `Int64` overflow.
+pub fn Duration::checked_add(self : Duration, other : Duration) -> Duration? {
+  match checked_i64_add(self.nanoseconds, other.nanoseconds) {
+    Some(ns) => Some(Duration::nanoseconds(ns))
+    None => None
+  }
+}
+
+///|
+/// Subtract one duration from another, returning `None` on `Int64` overflow.
+pub fn Duration::checked_sub(self : Duration, other : Duration) -> Duration? {
+  match checked_i64_sub(self.nanoseconds, other.nanoseconds) {
+    Some(ns) => Some(Duration::nanoseconds(ns))
+    None => None
+  }
 }
 
 ///|
@@ -1426,20 +1470,74 @@ pub impl Neg for Duration with fn neg(self) -> Duration {
 
 ///|
 /// Add a Duration to this DateTime.
+///
+/// This wraps on `Int64` overflow. Use `checked_add` when overflow or a
+/// DateTime outside the representable Unix-nanoseconds range should return
+/// `None`.
 pub fn DateTime::add(self : DateTime, d : Duration) -> DateTime {
   DateTime::from_unix_nanos(self.to_unix_nanos() + d.nanoseconds)
 }
 
 ///|
 /// Subtract a Duration from this DateTime.
+///
+/// This wraps on `Int64` overflow. Use `checked_sub` when overflow or a
+/// DateTime outside the representable Unix-nanoseconds range should return
+/// `None`.
 pub fn DateTime::sub(self : DateTime, d : Duration) -> DateTime {
   DateTime::from_unix_nanos(self.to_unix_nanos() - d.nanoseconds)
 }
 
 ///|
 /// Compute `self - other` as a Duration (may be negative).
+///
+/// This wraps on `Int64` overflow. Use `checked_diff` when overflow or a
+/// DateTime outside the representable Unix-nanoseconds range should return
+/// `None`.
 pub fn DateTime::diff(self : DateTime, other : DateTime) -> Duration {
   { nanoseconds: self.to_unix_nanos() - other.to_unix_nanos() }
+}
+
+///|
+/// Add a Duration to this DateTime, returning `None` on `Int64` overflow or
+/// when this DateTime is outside the representable Unix-nanoseconds range.
+pub fn DateTime::checked_add(self : DateTime, d : Duration) -> DateTime? {
+  match self.to_unix_nanos_checked() {
+    Some(ns) =>
+      match checked_i64_add(ns, d.nanoseconds) {
+        Some(result) => Some(DateTime::from_unix_nanos(result))
+        None => None
+      }
+    None => None
+  }
+}
+
+///|
+/// Subtract a Duration from this DateTime, returning `None` on `Int64` overflow
+/// or when this DateTime is outside the representable Unix-nanoseconds range.
+pub fn DateTime::checked_sub(self : DateTime, d : Duration) -> DateTime? {
+  match self.to_unix_nanos_checked() {
+    Some(ns) =>
+      match checked_i64_sub(ns, d.nanoseconds) {
+        Some(result) => Some(DateTime::from_unix_nanos(result))
+        None => None
+      }
+    None => None
+  }
+}
+
+///|
+/// Compute `self - other` as a Duration, returning `None` on `Int64` overflow
+/// or when either DateTime is outside the representable Unix-nanoseconds range.
+pub fn DateTime::checked_diff(self : DateTime, other : DateTime) -> Duration? {
+  match (self.to_unix_nanos_checked(), other.to_unix_nanos_checked()) {
+    (Some(a), Some(b)) =>
+      match checked_i64_sub(a, b) {
+        Some(ns) => Some(Duration::nanoseconds(ns))
+        None => None
+      }
+    _ => None
+  }
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -1308,6 +1308,30 @@ test "Duration::checked_multiply" {
 }
 
 ///|
+test "Duration::checked_add and checked_sub" {
+  assert_true(
+    @tempo.Duration::seconds(2L).checked_add(@tempo.Duration::seconds(3L)) ==
+    Some(@tempo.Duration::seconds(5L)),
+  )
+  assert_true(
+    @tempo.Duration::nanoseconds(@tempo.DateTime::max_unix_nanos()).checked_add(
+      @tempo.Duration::nanoseconds(1L),
+    )
+    is None,
+  )
+  assert_true(
+    @tempo.Duration::seconds(5L).checked_sub(@tempo.Duration::seconds(3L)) ==
+    Some(@tempo.Duration::seconds(2L)),
+  )
+  assert_true(
+    @tempo.Duration::nanoseconds(@tempo.DateTime::min_unix_nanos()).checked_sub(
+      @tempo.Duration::nanoseconds(1L),
+    )
+    is None,
+  )
+}
+
+///|
 test "Duration::divide" {
   assert_eq(
     @tempo.Duration::seconds(6L).divide(2L),
@@ -1374,6 +1398,39 @@ test "DateTime::diff negative" {
   let b = @tempo.DateTime::from_unix_seconds(0L)
   let d = b.diff(a)
   assert_eq(d.as_nanoseconds(), -3_600_000_000_000L)
+}
+
+///|
+test "DateTime::checked_add and checked_sub" {
+  let epoch = @tempo.DateTime::epoch()
+  let one_hour = @tempo.Duration::hours(1L)
+  assert_true(epoch.checked_add(one_hour) == Some(epoch.add(one_hour)))
+  assert_true(epoch.checked_sub(one_hour) == Some(epoch.sub(one_hour)))
+  let far_future = @tempo.DateTime::parse("3000-01-01T00:00:00Z")
+  assert_true(far_future.checked_add(@tempo.Duration::seconds(1L)) is None)
+  assert_true(far_future.checked_sub(@tempo.Duration::seconds(1L)) is None)
+  assert_true(
+    @tempo.DateTime::from_unix_nanos(@tempo.DateTime::max_unix_nanos()).checked_add(
+      @tempo.Duration::nanoseconds(1L),
+    )
+    is None,
+  )
+  assert_true(
+    @tempo.DateTime::from_unix_nanos(@tempo.DateTime::min_unix_nanos()).checked_sub(
+      @tempo.Duration::nanoseconds(1L),
+    )
+    is None,
+  )
+}
+
+///|
+test "DateTime::checked_diff" {
+  let epoch = @tempo.DateTime::epoch()
+  let later = epoch.add(@tempo.Duration::hours(1L))
+  assert_true(later.checked_diff(epoch) == Some(@tempo.Duration::hours(1L)))
+  let far_future = @tempo.DateTime::parse("3000-01-01T00:00:00Z")
+  assert_true(far_future.checked_diff(epoch) is None)
+  assert_true(epoch.checked_diff(far_future) is None)
 }
 
 ///|


### PR DESCRIPTION
Closes tempo-4h4.5.

Adds Option-returning checked arithmetic for DateTime add/sub/diff and Duration add/sub while leaving existing infallible arithmetic unchanged and documented as wrapping on Int64 overflow.

Verification:
- moon info && moon fmt
- moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native

Interface check: src/pkg.generated.mbti adds exactly DateTime::checked_add, DateTime::checked_sub, DateTime::checked_diff, Duration::checked_add, and Duration::checked_sub.

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: 96d7af87ff1eb851761e89e79327352968015cce
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: 96d7af87ff1eb851761e89e79327352968015cce
  - output tail:
```text
Total tests: 223, passed: 223, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: 96d7af87ff1eb851761e89e79327352968015cce
  - output tail:
```text
Total tests: 223, passed: 223, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: 96d7af87ff1eb851761e89e79327352968015cce
  - output tail:
```text
Total tests: 223, passed: 223, failed: 0.
```