### PR TITLE
Add Hash derives for tempo core types

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -17,7 +17,7 @@ pub struct Date {
   year : Int
   month : Int
   day : Int
-} derive(Compare, Eq)
+} derive(Compare, Eq, Hash)
 pub fn Date::add_days(Self, Int) -> Self
 pub fn Date::add_months(Self, Int) -> Self
 pub fn Date::add_years(Self, Int) -> Self
@@ -60,7 +60,7 @@ pub fn DateInterval::overlaps(Self, Self) -> Bool
 pub struct DateTime {
   date : Date
   time : Time
-} derive(Compare, Eq)
+} derive(Compare, Eq, Hash)
 pub fn DateTime::add(Self, Duration) -> Self
 pub fn DateTime::checked_add(Self, Duration) -> Self?
 pub fn DateTime::checked_diff(Self, Self) -> Duration?
@@ -113,7 +113,7 @@ pub impl Show for DateTime
 
 pub struct Duration {
   nanoseconds : Int64
-} derive(Compare, Eq)
+} derive(Compare, Eq, Hash)
 pub fn Duration::abs(Self) -> Self
 pub fn Duration::as_days(Self) -> Int64
 pub fn Duration::as_hours(Self) -> Int64
@@ -187,7 +187,7 @@ pub struct Time {
   minute : Int
   second : Int
   nanosecond : Int
-} derive(Compare, Eq)
+} derive(Compare, Eq, Hash)
 pub fn Time::clamp(Self, Self, Self) -> Self
 pub fn Time::format(Self) -> String
 pub fn Time::is_after(Self, Self) -> Bool

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -23,7 +23,7 @@ pub struct Date {
   year : Int
   month : Int // 1–12
   day : Int // 1–31
-} derive(Eq, Compare)
+} derive(Eq, Compare, Hash)
 
 ///|
 /// A calendar date interval with an inclusive end date: `[start, end]`.
@@ -264,7 +264,7 @@ pub struct Time {
   minute : Int // 0–59
   second : Int // 0–59
   nanosecond : Int // 0–999_999_999
-} derive(Eq, Compare)
+} derive(Eq, Compare, Hash)
 
 ///|
 /// Units supported by `DateTime::truncate_to` and `DateTime::round_to`, ordered
@@ -309,7 +309,7 @@ pub impl Show for RoundMode with fn output(self, logger) {
 pub struct DateTime {
   date : Date
   time : Time
-} derive(Eq, Compare)
+} derive(Eq, Compare, Hash)
 
 ///|
 /// A DateTime interval with a half-open end instant: `[start, end)`.
@@ -327,7 +327,7 @@ pub(all) struct Interval {
 /// A signed duration stored as total nanoseconds.
 pub struct Duration {
   nanoseconds : Int64
-} derive(Eq, Compare)
+} derive(Eq, Compare, Hash)
 
 // ─── Calendar helpers ─────────────────────────────────────────────────────────
 

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -1459,6 +1459,57 @@ test "DateTime compare" {
 }
 
 ///|
+test "core types are hash collection keys" {
+  let dates : Map[@tempo.Date, String] = {}
+  dates.set(@tempo.Date::new(2024, 1, 1), "new-year")
+  dates.set(@tempo.Date::new(2024, 2, 29), "leap")
+  assert_true(dates.get(@tempo.Date::new(2024, 1, 1)) == Some("new-year"))
+  assert_true(dates.get(@tempo.Date::new(2024, 2, 29)) == Some("leap"))
+  let date_set : Set[@tempo.Date] = Set([
+    @tempo.Date::new(2024, 1, 1),
+    @tempo.Date::new(2024, 2, 29),
+  ])
+  assert_eq(date_set.contains(@tempo.Date::new(2024, 2, 29)), true)
+  let times : Map[@tempo.Time, Int] = {}
+  times.set(@tempo.Time::new(9, 30, 0, 0), 1)
+  times.set(@tempo.Time::new(17, 45, 30, 123), 2)
+  assert_true(times.get(@tempo.Time::new(9, 30, 0, 0)) == Some(1))
+  assert_true(times.get(@tempo.Time::new(17, 45, 30, 123)) == Some(2))
+  let time_set : Set[@tempo.Time] = Set([
+    @tempo.Time::new(9, 30, 0, 0),
+    @tempo.Time::new(17, 45, 30, 123),
+  ])
+  assert_eq(time_set.contains(@tempo.Time::new(17, 45, 30, 123)), true)
+  let date_times : Map[@tempo.DateTime, Int] = {}
+  date_times.set(@tempo.DateTime::parse("2024-01-01T00:00:00Z"), 1)
+  date_times.set(@tempo.DateTime::parse("2024-02-29T12:30:00Z"), 2)
+  assert_true(
+    date_times.get(@tempo.DateTime::parse("2024-01-01T00:00:00Z")) == Some(1),
+  )
+  assert_true(
+    date_times.get(@tempo.DateTime::parse("2024-02-29T12:30:00Z")) == Some(2),
+  )
+  let date_time_set : Set[@tempo.DateTime] = Set([
+    @tempo.DateTime::parse("2024-01-01T00:00:00Z"),
+    @tempo.DateTime::parse("2024-02-29T12:30:00Z"),
+  ])
+  assert_eq(
+    date_time_set.contains(@tempo.DateTime::parse("2024-02-29T12:30:00Z")),
+    true,
+  )
+  let durations : Map[@tempo.Duration, String] = {}
+  durations.set(@tempo.Duration::seconds(5L), "short")
+  durations.set(@tempo.Duration::hours(2L), "long")
+  assert_true(durations.get(@tempo.Duration::seconds(5L)) == Some("short"))
+  assert_true(durations.get(@tempo.Duration::hours(2L)) == Some("long"))
+  let duration_set : Set[@tempo.Duration] = Set([
+    @tempo.Duration::seconds(5L),
+    @tempo.Duration::hours(2L),
+  ])
+  assert_eq(duration_set.contains(@tempo.Duration::hours(2L)), true)
+}
+
+///|
 test "DateTime comparison helpers and elapsed wrappers" {
   let dt = @tempo.DateTime::parse("2024-03-15T12:00:00Z")
   let dt2 = dt.add(@tempo.Duration::hours(2L))


### PR DESCRIPTION
Closes tempo-dwz.1.

Adds Hash derives for Date, Time, DateTime, and Duration so they can be used as stdlib hash Map/Set keys. Adds blackbox coverage that inserts and looks up equal keys for all four core types.

Verification:
- moon info && moon fmt
- moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: aee646817c1d2c29f76af35237b9e128bbbf51d6
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: aee646817c1d2c29f76af35237b9e128bbbf51d6
  - output tail:
```text
Total tests: 224, passed: 224, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: aee646817c1d2c29f76af35237b9e128bbbf51d6
  - output tail:
```text
Total tests: 224, passed: 224, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: aee646817c1d2c29f76af35237b9e128bbbf51d6
  - output tail:
```text
Total tests: 224, passed: 224, failed: 0.
```