### PR TITLE
Add ISO 8601 Duration round-trip

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -128,6 +128,7 @@ pub fn Duration::checked_multiply(Self, Int64) -> Self?
 pub fn Duration::checked_sub(Self, Self) -> Self?
 pub fn Duration::days(Int64) -> Self
 pub fn Duration::divide(Self, Int64) -> Self raise TempoError
+pub fn Duration::format_iso(Self) -> String
 pub fn Duration::hours(Int64) -> Self
 pub fn Duration::is_negative(Self) -> Bool
 pub fn Duration::is_positive(Self) -> Bool
@@ -137,6 +138,7 @@ pub fn Duration::milliseconds(Int64) -> Self
 pub fn Duration::minutes(Int64) -> Self
 pub fn Duration::multiply(Self, Int64) -> Self
 pub fn Duration::nanoseconds(Int64) -> Self
+pub fn Duration::parse_iso(String) -> Self raise TempoError
 pub fn Duration::seconds(Int64) -> Self
 pub fn Duration::signum(Self) -> Int
 pub fn Duration::weeks(Int64) -> Self

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -1941,7 +1941,7 @@ fn parse_frac_ns(view : StringView) -> (Int, StringView) raise TempoError {
 }
 
 ///|
-let duration_calendar_units_error : String = "calendar units (years/months) are not representable as a fixed Duration; use a Period instead"
+let duration_calendar_units_error : String = "calendar units (years/months) are not representable as a fixed Duration; use a calendar-period representation instead"
 
 ///|
 fn parse_duration_number(
@@ -2011,7 +2011,7 @@ fn duration_reject_time_order() -> Unit raise TempoError {
 /// `PnDTnHnMnS`, with optional fractional seconds and leading sign.
 ///
 /// Calendar units (`Y` years or date-part `M` months) raise `TempoError`; use a
-/// future calendar `Period` type for those units.
+/// calendar-period representation for those units.
 pub fn Duration::parse_iso(s : String) -> Duration raise TempoError {
   let (negative, v) = match s.view() {
     ['-', .. rest] => (true, rest)
@@ -2090,7 +2090,9 @@ pub fn Duration::parse_iso(s : String) -> Duration raise TempoError {
           }
           ['.', .. frac_view] => {
             if !in_time {
-              raise TempoError("fractional seconds require 'T'")
+              raise TempoError(
+                "fractional components are only supported for seconds in the time part after 'T'",
+              )
             }
             if time_rank >= 3 {
               duration_reject_time_order()

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -1213,6 +1213,9 @@ let ns_per_min : Int64 = 60_000_000_000L
 let ns_per_hour : Int64 = 3_600_000_000_000L
 
 ///|
+let ns_per_day : Int64 = 86_400_000_000_000L
+
+///|
 let int64_min_value : Int64 = -9_223_372_036_854_775_808L
 
 ///|
@@ -1747,6 +1750,57 @@ pub fn Time::format(self : Time) -> String {
 }
 
 ///|
+/// Format this fixed-length duration as a canonical ISO 8601 duration string.
+///
+/// Calendar units (years and months) are not representable as a fixed
+/// nanosecond duration and are therefore never emitted.
+pub fn Duration::format_iso(self : Duration) -> String {
+  let ns = self.nanoseconds
+  if ns == 0L {
+    "PT0S"
+  } else {
+    let sign = if ns < 0L { "-" } else { "" }
+    // Divide before taking absolute values so Int64::min_value formats without
+    // negating the whole duration.
+    let days = ns / ns_per_day
+    let rem = ns - days * ns_per_day
+    let hours = rem / ns_per_hour
+    let rem = rem - hours * ns_per_hour
+    let minutes = rem / ns_per_min
+    let rem = rem - minutes * ns_per_min
+    let seconds = rem / ns_per_sec
+    let frac_ns = rem - seconds * ns_per_sec
+    let days = if days < 0L { -days } else { days }
+    let hours = if hours < 0L { -hours } else { hours }
+    let minutes = if minutes < 0L { -minutes } else { minutes }
+    let seconds = if seconds < 0L { -seconds } else { seconds }
+    let frac_ns = (if frac_ns < 0L { -frac_ns } else { frac_ns }).to_int()
+    let has_time = hours > 0L || minutes > 0L || seconds > 0L || frac_ns > 0
+    let buf = StringBuilder()
+    buf.write_string(sign)
+    buf.write_string("P")
+    if days > 0L {
+      buf.write_string("\{days}D")
+    }
+    if has_time {
+      buf.write_string("T")
+      if hours > 0L {
+        buf.write_string("\{hours}H")
+      }
+      if minutes > 0L {
+        buf.write_string("\{minutes}M")
+      }
+      if frac_ns > 0 {
+        buf.write_string("\{seconds}.\{fmt_frac(frac_ns)}S")
+      } else if seconds > 0L {
+        buf.write_string("\{seconds}S")
+      }
+    }
+    buf.to_string()
+  }
+}
+
+///|
 pub impl Show for Date with fn output(self, logger) {
   logger.write_string(
     "\{pad4_year(self.year)}-\{pad2(self.month)}-\{pad2(self.day)}",
@@ -1884,6 +1938,184 @@ fn parse_frac_ns(view : StringView) -> (Int, StringView) raise TempoError {
       }
     }
   }
+}
+
+///|
+let duration_calendar_units_error : String = "calendar units (years/months) are not representable as a fixed Duration; use a Period instead"
+
+///|
+fn parse_duration_number(
+  view : StringView,
+) -> (Int64, StringView) raise TempoError {
+  for v = view, count = 0, acc = 0L {
+    match v {
+      ['0'..='9' as c, .. rest] => {
+        let digit = (c.to_int() - '0').to_int64()
+        if acc > (int64_max_value - digit) / 10L {
+          raise TempoError("duration component overflows Int64")
+        }
+        continue rest, count + 1, acc * 10L + digit
+      }
+      _ => {
+        if count == 0 {
+          raise TempoError("expected duration component digits")
+        }
+        break (acc, v)
+      }
+    }
+  }
+}
+
+///|
+fn duration_component_ns(
+  amount : Int64,
+  unit : Int64,
+) -> Int64 raise TempoError {
+  match Duration::nanoseconds(unit).checked_multiply(amount) {
+    Some(d) => d.nanoseconds
+    None => raise TempoError("duration component overflows Int64 nanoseconds")
+  }
+}
+
+///|
+fn duration_accumulate(
+  total : Int64,
+  component : Int64,
+  negative : Bool,
+) -> Int64 raise TempoError {
+  let next = if negative {
+    checked_i64_sub(total, component)
+  } else {
+    checked_i64_add(total, component)
+  }
+  match next {
+    Some(ns) => ns
+    None => raise TempoError("duration overflows Int64 nanoseconds")
+  }
+}
+
+///|
+fn duration_reject_time_component_without_t(
+  unit : Char,
+) -> Unit raise TempoError {
+  raise TempoError("time component '\{unit}' requires 'T'")
+}
+
+///|
+fn duration_reject_time_order() -> Unit raise TempoError {
+  raise TempoError("duration time components are repeated or out of order")
+}
+
+///|
+/// Parse an ISO 8601 duration string in the fixed-nanosecond subset:
+/// `PnDTnHnMnS`, with optional fractional seconds and leading sign.
+///
+/// Calendar units (`Y` years or date-part `M` months) raise `TempoError`; use a
+/// future calendar `Period` type for those units.
+pub fn Duration::parse_iso(s : String) -> Duration raise TempoError {
+  let (negative, v) = match s.view() {
+    ['-', .. rest] => (true, rest)
+    ['+', .. rest] => (false, rest)
+    v => (false, v)
+  }
+  let v = match v {
+    ['P', .. rest] => rest
+    [c, ..] => raise TempoError("expected 'P', got '\{c}'")
+    [] => raise TempoError("unexpected end of input, expected 'P'")
+  }
+  let total = for v = v, total = 0L, saw_component = false, in_time = false, saw_day = false, time_rank = 0 {
+    match v {
+      [] =>
+        if saw_component {
+          break total
+        } else {
+          raise TempoError("expected duration component")
+        }
+      ['T', .. rest] => {
+        if in_time {
+          raise TempoError("duration contains repeated 'T'")
+        }
+        match rest {
+          [] => raise TempoError("expected time component after 'T'")
+          _ => continue rest, total, saw_component, true, saw_day, time_rank
+        }
+      }
+      ['0'..='9', ..] => {
+        let (amount, rest) = parse_duration_number(v)
+        match rest {
+          ['Y', ..] => raise TempoError(duration_calendar_units_error)
+          ['D', .. rest] => {
+            if in_time {
+              raise TempoError("date component 'D' is not allowed after 'T'")
+            }
+            if saw_day {
+              raise TempoError("duration day component is repeated")
+            }
+            let component = duration_component_ns(amount, ns_per_day)
+            let total = duration_accumulate(total, component, negative)
+            continue rest, total, true, in_time, true, time_rank
+          }
+          ['H', .. rest] => {
+            if !in_time {
+              duration_reject_time_component_without_t('H')
+            }
+            if time_rank >= 1 {
+              duration_reject_time_order()
+            }
+            let component = duration_component_ns(amount, ns_per_hour)
+            let total = duration_accumulate(total, component, negative)
+            continue rest, total, true, in_time, saw_day, 1
+          }
+          ['M', .. rest] =>
+            if in_time {
+              if time_rank >= 2 {
+                duration_reject_time_order()
+              }
+              let component = duration_component_ns(amount, ns_per_min)
+              let total = duration_accumulate(total, component, negative)
+              continue rest, total, true, in_time, saw_day, 2
+            } else {
+              raise TempoError(duration_calendar_units_error)
+            }
+          ['S', .. rest] => {
+            if !in_time {
+              duration_reject_time_component_without_t('S')
+            }
+            if time_rank >= 3 {
+              duration_reject_time_order()
+            }
+            let component = duration_component_ns(amount, ns_per_sec)
+            let total = duration_accumulate(total, component, negative)
+            continue rest, total, true, in_time, saw_day, 3
+          }
+          ['.', .. frac_view] => {
+            if !in_time {
+              raise TempoError("fractional seconds require 'T'")
+            }
+            if time_rank >= 3 {
+              duration_reject_time_order()
+            }
+            let seconds = duration_component_ns(amount, ns_per_sec)
+            let total = duration_accumulate(total, seconds, negative)
+            let (frac_ns, rest) = parse_frac_ns(frac_view)
+            let rest = match rest {
+              ['S', .. rest] => rest
+              [c, ..] => raise TempoError("expected 'S', got '\{c}'")
+              [] => raise TempoError("unexpected end of input, expected 'S'")
+            }
+            let total = duration_accumulate(total, frac_ns.to_int64(), negative)
+            continue rest, total, true, in_time, saw_day, 3
+          }
+          [] =>
+            raise TempoError("unexpected end of input, expected duration unit")
+          [c, ..] => raise TempoError("expected duration unit, got '\{c}'")
+        }
+      }
+      ['Y', ..] => raise TempoError(duration_calendar_units_error)
+      [c, ..] => raise TempoError("expected duration component, got '\{c}'")
+    }
+  }
+  Duration::nanoseconds(total)
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -1159,6 +1159,70 @@ test "DateTime::parse roundtrip" {
 }
 
 ///|
+test "Duration::format_iso canonical components" {
+  assert_eq(
+    (@tempo.Duration::hours(2L) + @tempo.Duration::minutes(30L)).format_iso(),
+    "PT2H30M",
+  )
+  assert_eq(
+    (@tempo.Duration::days(1L) + @tempo.Duration::hours(2L)).format_iso(),
+    "P1DT2H",
+  )
+  assert_eq(@tempo.Duration::milliseconds(500L).format_iso(), "PT0.5S")
+  assert_eq(@tempo.Duration::seconds(0L).format_iso(), "PT0S")
+  assert_eq(@tempo.Duration::hours(-1L).format_iso(), "-PT1H")
+}
+
+///|
+test "Duration::parse_iso fixed-unit components" {
+  assert_eq(
+    @tempo.Duration::parse_iso("PT2H30M"),
+    @tempo.Duration::minutes(150L),
+  )
+  assert_eq(
+    @tempo.Duration::parse_iso("P1DT2H30M45.5S"),
+    @tempo.Duration::days(1L) +
+    @tempo.Duration::hours(2L) +
+    @tempo.Duration::minutes(30L) +
+    @tempo.Duration::seconds(45L) +
+    @tempo.Duration::milliseconds(500L),
+  )
+  assert_eq(@tempo.Duration::parse_iso("-PT1H"), @tempo.Duration::hours(-1L))
+  assert_eq(@tempo.Duration::parse_iso("PT0S"), @tempo.Duration::seconds(0L))
+}
+
+///|
+test "Duration::parse_iso round-trips format_iso" {
+  let zero = @tempo.Duration::seconds(0L)
+  assert_eq(@tempo.Duration::parse_iso(zero.format_iso()), zero)
+  let hours_minutes = @tempo.Duration::hours(2L) + @tempo.Duration::minutes(30L)
+  assert_eq(
+    @tempo.Duration::parse_iso(hours_minutes.format_iso()),
+    hours_minutes,
+  )
+  let days_hours = @tempo.Duration::days(1L) + @tempo.Duration::hours(2L)
+  assert_eq(@tempo.Duration::parse_iso(days_hours.format_iso()), days_hours)
+  let fractional = @tempo.Duration::nanoseconds(1_234_567_890L)
+  assert_eq(@tempo.Duration::parse_iso(fractional.format_iso()), fractional)
+  let negative = @tempo.Duration::nanoseconds(-1_234_567_890L)
+  assert_eq(@tempo.Duration::parse_iso(negative.format_iso()), negative)
+}
+
+///|
+test "Duration::parse_iso rejects calendar units but accepts minutes" {
+  assert_true((try? @tempo.Duration::parse_iso("P1Y")) is Err(_))
+  assert_true((try? @tempo.Duration::parse_iso("P3M")) is Err(_))
+  assert_eq(@tempo.Duration::parse_iso("PT3M"), @tempo.Duration::minutes(3L))
+}
+
+///|
+test "Duration::parse_iso raises on component overflow" {
+  assert_true(
+    (try? @tempo.Duration::parse_iso("PT9223372036854775807H")) is Err(_),
+  )
+}
+
+///|
 test "Duration::days" {
   let d = @tempo.Duration::days(1L)
   assert_eq(d.as_seconds(), 86_400L)


### PR DESCRIPTION
Closes tempo-z7j.4.\n\nAdds canonical ISO 8601 formatting and parsing for the fixed-nanosecond Duration subset (days, hours, minutes, seconds, and fractional seconds). Calendar years/months are rejected with a Period-directed TempoError because they are not fixed durations.\n\nVerification:\n- moon fmt --check\n- moon test --target wasm-gc\n- moon test --target js\n- moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: f0fec2c2a8078b81bb4d95e50e91007a04c4edb5
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: f0fec2c2a8078b81bb4d95e50e91007a04c4edb5
  - output tail:
```text
Total tests: 229, passed: 229, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: f0fec2c2a8078b81bb4d95e50e91007a04c4edb5
  - output tail:
```text
Total tests: 229, passed: 229, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: f0fec2c2a8078b81bb4d95e50e91007a04c4edb5
  - output tail:
```text
Total tests: 229, passed: 229, failed: 0.
```