### PR TITLE
Add canonical JSON serde

### DIFF
--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/int",
+  "moonbitlang/core/json",
 }
 
 options(

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "brickfrog/tempo"
 
+import {
+  "moonbitlang/core/json",
+}
+
 // Values
 pub fn days_in_month(Int, Int) -> Int
 
@@ -47,6 +51,8 @@ pub fn Date::with_day(Self, Int) -> Self raise TempoError
 pub fn Date::with_month(Self, Int) -> Self raise TempoError
 pub fn Date::with_year(Self, Int) -> Self raise TempoError
 pub impl Show for Date
+pub impl ToJson for Date
+pub impl @json.FromJson for Date
 
 pub(all) struct DateInterval {
   start : Date
@@ -110,6 +116,8 @@ pub fn DateTime::with_second(Self, Int) -> Self raise TempoError
 pub fn DateTime::with_time(Self, Time) -> Self
 pub fn DateTime::with_year(Self, Int) -> Self raise TempoError
 pub impl Show for DateTime
+pub impl ToJson for DateTime
+pub impl @json.FromJson for DateTime
 
 pub struct Duration {
   nanoseconds : Int64
@@ -146,6 +154,8 @@ pub impl Add for Duration
 pub impl Neg for Duration
 pub impl Show for Duration
 pub impl Sub for Duration
+pub impl ToJson for Duration
+pub impl @json.FromJson for Duration
 
 pub(all) struct Interval {
   start : DateTime
@@ -203,6 +213,8 @@ pub fn Time::with_minute(Self, Int) -> Self raise TempoError
 pub fn Time::with_nanosecond(Self, Int) -> Self raise TempoError
 pub fn Time::with_second(Self, Int) -> Self raise TempoError
 pub impl Show for Time
+pub impl ToJson for Time
+pub impl @json.FromJson for Time
 
 pub(all) enum TimeUnit {
   Second

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -1801,6 +1801,74 @@ pub fn Duration::format_iso(self : Duration) -> String {
 }
 
 ///|
+fn[T] json_decode_error(
+  path : @json.JsonPath,
+  msg : String,
+) -> T raise @json.JsonDecodeError {
+  raise @json.JsonDecodeError((path, msg))
+}
+
+///|
+pub impl ToJson for Date with fn to_json(self : Date) -> Json {
+  Json::string(self.format())
+}
+
+///|
+pub impl @json.FromJson for Date with fn from_json(json, path) {
+  guard json is String(s) else {
+    json_decode_error(path, "Date::from_json: expected string")
+  }
+  Date::parse(s) catch {
+    TempoError(msg) => json_decode_error(path, "Date::from_json: " + msg)
+  }
+}
+
+///|
+pub impl ToJson for Time with fn to_json(self : Time) -> Json {
+  Json::string(self.format())
+}
+
+///|
+pub impl @json.FromJson for Time with fn from_json(json, path) {
+  guard json is String(s) else {
+    json_decode_error(path, "Time::from_json: expected string")
+  }
+  Time::parse(s) catch {
+    TempoError(msg) => json_decode_error(path, "Time::from_json: " + msg)
+  }
+}
+
+///|
+pub impl ToJson for DateTime with fn to_json(self : DateTime) -> Json {
+  Json::string(self.format())
+}
+
+///|
+pub impl @json.FromJson for DateTime with fn from_json(json, path) {
+  guard json is String(s) else {
+    json_decode_error(path, "DateTime::from_json: expected string")
+  }
+  DateTime::parse(s) catch {
+    TempoError(msg) => json_decode_error(path, "DateTime::from_json: " + msg)
+  }
+}
+
+///|
+pub impl ToJson for Duration with fn to_json(self : Duration) -> Json {
+  Json::string(self.format_iso())
+}
+
+///|
+pub impl @json.FromJson for Duration with fn from_json(json, path) {
+  guard json is String(s) else {
+    json_decode_error(path, "Duration::from_json: expected string")
+  }
+  Duration::parse_iso(s) catch {
+    TempoError(msg) => json_decode_error(path, "Duration::from_json: " + msg)
+  }
+}
+
+///|
 pub impl Show for Date with fn output(self, logger) {
   logger.write_string(
     "\{pad4_year(self.year)}-\{pad2(self.month)}-\{pad2(self.day)}",

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -1223,6 +1223,67 @@ test "Duration::parse_iso raises on component overflow" {
 }
 
 ///|
+fn assert_json_string(json : Json, expected : String) -> Unit raise {
+  match json {
+    String(actual) => assert_eq(actual, expected)
+    _ => assert_true(false)
+  }
+}
+
+///|
+test "JSON serializes tempo values as canonical strings" {
+  let date = @tempo.Date::parse("2024-03-15")
+  assert_json_string(date.to_json(), "2024-03-15")
+  let time = @tempo.Time::parse("14:31:43.5")
+  assert_json_string(time.to_json(), "14:31:43.5")
+  let datetime = @tempo.DateTime::parse("2024-07-21T17:11:00Z")
+  assert_json_string(datetime.to_json(), "2024-07-21T17:11:00Z")
+  let fractional = @tempo.DateTime::parse("2024-03-15T12:34:56.123456789Z")
+  assert_json_string(fractional.to_json(), "2024-03-15T12:34:56.123456789Z")
+  let duration = @tempo.Duration::hours(2L) + @tempo.Duration::minutes(30L)
+  assert_eq(duration.format_iso(), "PT2H30M")
+  assert_json_string(duration.to_json(), duration.format_iso())
+}
+
+///|
+test "JSON deserializes tempo canonical strings" {
+  let date = @tempo.Date::parse("2024-03-15")
+  assert_eq((@json.from_json(date.to_json()) : @tempo.Date), date)
+  let time = @tempo.Time::parse("14:31:43.5")
+  assert_eq((@json.from_json(time.to_json()) : @tempo.Time), time)
+  let datetime = @tempo.DateTime::parse("2024-03-15T12:34:56.123456789Z")
+  assert_eq((@json.from_json(datetime.to_json()) : @tempo.DateTime), datetime)
+  let duration = @tempo.Duration::hours(2L) + @tempo.Duration::minutes(30L)
+  assert_eq((@json.from_json(duration.to_json()) : @tempo.Duration), duration)
+}
+
+///|
+test "JSON deserialization rejects non-strings and invalid strings" {
+  assert_true((try? (@json.from_json(Json::number(1)) : @tempo.Date)) is Err(_))
+  assert_true((try? (@json.from_json(Json::number(1)) : @tempo.Time)) is Err(_))
+  assert_true(
+    (try? (@json.from_json(Json::number(1)) : @tempo.DateTime)) is Err(_),
+  )
+  assert_true(
+    (try? (@json.from_json(Json::number(1)) : @tempo.Duration)) is Err(_),
+  )
+  assert_true(
+    (try? (@json.from_json(Json::string("not-a-date")) : @tempo.Date)) is Err(_),
+  )
+  assert_true(
+    (try? (@json.from_json(Json::string("not-a-time")) : @tempo.Time)) is Err(_),
+  )
+  assert_true(
+    (try? (@json.from_json(Json::string("not-a-datetime")) : @tempo.DateTime))
+    is Err(_),
+  )
+  assert_true(
+    (try? (@json.from_json(Json::string("not-a-duration")) : @tempo.Duration))
+    is Err(_),
+  )
+}
+
+///|
 test "Duration::days" {
   let d = @tempo.Duration::days(1L)
   assert_eq(d.as_seconds(), 86_400L)


### PR DESCRIPTION
Closes tempo-dwz.2.

What:
- Implements manual ToJson and @json.FromJson for Date, Time, DateTime, and Duration using canonical JSON strings.
- Adds blackbox coverage for JSON string output, @json.from_json round-trips, and non-string plus invalid-string failures.
- Updates moon info output so src/pkg.generated.mbti exposes the new trait impls.

Verify:
- moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: 54c82a1c5add2464215030ad909016182cfa2a4f
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: 54c82a1c5add2464215030ad909016182cfa2a4f
  - output tail:
```text
Total tests: 232, passed: 232, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: 54c82a1c5add2464215030ad909016182cfa2a4f
  - output tail:
```text
Total tests: 232, passed: 232, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: 54c82a1c5add2464215030ad909016182cfa2a4f
  - output tail:
```text
Total tests: 232, passed: 232, failed: 0.
```