### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-02
+
+### Added
+
+- `Hash` on `Date`, `Time`, `DateTime`, and `Duration`, so they can be used as
+  keys in the stdlib hash `Map`/`Set`. (#31)
+- `Duration::format_iso` / `parse_iso` for ISO 8601 duration strings (the
+  `PnDTnHnMnS` subset with fractional seconds). Years and months are rejected as
+  calendar units. (#32)
+- JSON via `moonbitlang/core/json`: `ToJson` / `FromJson` for `Date`, `Time`,
+  `DateTime`, and `Duration`, encoded as their canonical RFC 3339 / ISO 8601
+  strings rather than field objects. (#33)
+- Int64 overflow safety: `DateTime::min_unix_nanos` / `max_unix_nanos` and
+  `to_unix_nanos_checked` (#29); `DateTime::checked_add` / `checked_sub` /
+  `checked_diff` and `Duration::checked_add` / `checked_sub`, each returning
+  `None` on overflow or an out-of-range operand (#30).
+
+### Changed
+
+- Documented that `to_unix_nanos` and the infallible `add` / `sub` / `diff`
+  operators wrap on Int64 overflow; the `checked_*` variants are the
+  overflow-safe alternative. (#29, #30)
+
 ## [0.5.0] - 2026-06-02
 
 ### Added

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -377,6 +377,69 @@ test {
 }
 ```
 
+## Hashing
+
+`Date`, `Time`, `DateTime`, and `Duration` derive `Hash`, so they work as keys
+in the stdlib hash `Map`/`Set`.
+
+```moonbit nocheck
+///|
+test {
+  let counts : Map[@tempo.Date, Int] = {}
+  counts[@tempo.Date::new(2024, 3, 15)] = 3
+  assert_eq(counts[@tempo.Date::new(2024, 3, 15)], Some(3))
+}
+```
+
+## ISO 8601 durations
+
+`Duration::format_iso`/`parse_iso` round-trip the `PnDTnHnMnS` subset (days,
+hours, minutes, seconds with fractions). Years and months are rejected as
+calendar units.
+
+```moonbit nocheck
+///|
+test {
+  let d = @tempo.Duration::hours(2L) + @tempo.Duration::minutes(30L)
+  inspect(d.format_iso(), content="PT2H30M")
+  assert_eq(@tempo.Duration::parse_iso("PT2H30M"), d)
+}
+```
+
+## JSON
+
+`Date`, `Time`, `DateTime`, and `Duration` serialize to their canonical strings
+(RFC 3339 / ISO 8601) via `moonbitlang/core/json` — not field objects.
+
+```moonbit nocheck
+///|
+test {
+  let dt = @tempo.DateTime::parse("2024-07-21T17:11:00Z")
+  inspect(dt.to_json().stringify(), content="\"2024-07-21T17:11:00Z\"")
+}
+```
+
+## Overflow safety
+
+`to_unix_nanos` and the `add`/`sub`/`diff` operators wrap silently outside the
+Int64-nanosecond range (~1677–2262). The checked variants return `None` instead:
+`to_unix_nanos_checked`, `DateTime::checked_add`/`checked_sub`/`checked_diff`,
+and `Duration::checked_add`/`checked_sub`. `min_unix_nanos`/`max_unix_nanos`
+document the bounds.
+
+```moonbit nocheck
+///|
+test {
+  let far = @tempo.DateTime::parse("3000-01-01T00:00:00Z")
+  assert_eq(far.to_unix_nanos_checked(), None)
+
+  match @tempo.DateTime::epoch().checked_add(@tempo.Duration::hours(1L)) {
+    Some(dt) => inspect(dt.format(), content="1970-01-01T01:00:00Z")
+    None => ()
+  }
+}
+```
+
 ## Date and Time parsing/formatting
 
 ```moonbit nocheck

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -386,8 +386,8 @@ in the stdlib hash `Map`/`Set`.
 ///|
 test {
   let counts : Map[@tempo.Date, Int] = {}
-  counts[@tempo.Date::new(2024, 3, 15)] = 3
-  assert_eq(counts[@tempo.Date::new(2024, 3, 15)], Some(3))
+  counts.set(@tempo.Date::new(2024, 3, 15), 3)
+  assert_eq(counts.get(@tempo.Date::new(2024, 3, 15)), Some(3))
 }
 ```
 

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "brickfrog/tempo"
 
-version = "0.5.0"
+version = "0.6.0"
 
 readme = "README.mbt.md"
 


### PR DESCRIPTION
Release prep for **v0.6.0** (robustness + ecosystem).

- `README.mbt.md` — add sections for hashing, ISO 8601 durations, JSON, and overflow safety.
- `CHANGELOG.md` — new `[0.6.0]` section (#29–#33).
- `moon.mod` — version `0.5.0` → `0.6.0`.

Docs/version only — no source changes. Tag, GitHub Release, and `moon publish` follow after merge.
