### PR TITLE
Add fixed offset datetime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,11 @@ You can browse and install extra skills here:
   `pad(n, width)` unless profiling shows formatting is a bottleneck.
 
 - **pad4_year abort on Int::min_value:** Intentional programmer-error trap.
-  `Int::min_value` cannot be negated to a positive `Int`. This year is not
-  constructable via `Date::new` — only via raw struct literal (caller bug).
-  Future option: handle via `Int64` arithmetic to eliminate the abort.
+  `Int::min_value` cannot be negated to a positive `Int`. This year can be
+  reached at the arithmetic envelope via `Date::add_days` carry from a
+  `Date::new`-constructable extreme year; ordinary calendar dates are
+  unaffected. Future option: handle via `Int64` arithmetic to eliminate the
+  abort.
 
 - **floor_div64 / floor_mod64:** Required. MoonBit stdlib does not provide floor
   division for `Int64`. MoonBit's `/` truncates toward zero; these round toward
@@ -78,3 +80,13 @@ You can browse and install extra skills here:
   seconds are always shown when hours and minutes are both zero.
 
 - **fmt_frac while loop:** Intentional. `StringView` lacks `trim_end(Char)`.
+
+- **FixedOffsetDateTime::format extreme-year abort:** Does NOT introduce a
+  distinct fallible-formatting contract. The abort arises from the same
+  bounded-`Int` date arithmetic (`Date::add_days`, `pad4_year`) used by
+  `Date`/`DateTime`; the local-time projection can carry into an
+  unrepresentable year only at year ≈ `Int` extremes. A
+  FixedOffsetDateTime-only constructor bound would make its domain inconsistent
+  with `DateTime` without solving the root cause, so this is documented and
+  tested as the current boundary. The real fix (checked / wider epoch-day
+  arithmetic) is tempo-oj8.

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -161,7 +161,7 @@ pub struct FixedOffsetDateTime {
   // private fields
 } derive(Compare, Eq)
 pub fn FixedOffsetDateTime::format(Self) -> String
-pub fn FixedOffsetDateTime::from_datetime_and_offset(DateTime, Int) -> Self
+pub fn FixedOffsetDateTime::from_datetime_and_offset(DateTime, Int) -> Self raise TempoError
 pub fn FixedOffsetDateTime::offset_seconds(Self) -> Int
 pub fn FixedOffsetDateTime::parse(String) -> Self raise TempoError
 pub fn FixedOffsetDateTime::to_utc(Self) -> DateTime

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -159,7 +159,7 @@ pub impl @json.FromJson for Duration
 
 pub struct FixedOffsetDateTime {
   // private fields
-} derive(Compare, Eq)
+} derive(Compare, Eq, Hash)
 pub fn FixedOffsetDateTime::format(Self) -> String
 pub fn FixedOffsetDateTime::from_datetime_and_offset(DateTime, Int) -> Self raise TempoError
 pub fn FixedOffsetDateTime::offset_seconds(Self) -> Int

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -157,6 +157,16 @@ pub impl Sub for Duration
 pub impl ToJson for Duration
 pub impl @json.FromJson for Duration
 
+pub struct FixedOffsetDateTime {
+  // private fields
+} derive(Compare, Eq)
+pub fn FixedOffsetDateTime::format(Self) -> String
+pub fn FixedOffsetDateTime::from_datetime_and_offset(DateTime, Int) -> Self
+pub fn FixedOffsetDateTime::offset_seconds(Self) -> Int
+pub fn FixedOffsetDateTime::parse(String) -> Self raise TempoError
+pub fn FixedOffsetDateTime::to_utc(Self) -> DateTime
+pub impl Show for FixedOffsetDateTime
+
 pub(all) struct Interval {
   start : DateTime
   end : DateTime

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -871,11 +871,26 @@ pub fn DateTime::to_time(self : DateTime) -> Time {
 /// remains tempo's primary timestamp type; this wrapper is for wire-format
 /// interop when a timestamp carries an explicit numeric offset but no IANA
 /// time zone.
+///
+/// Raises `TempoError` when `offset_seconds` is not whole-minute granularity or
+/// is outside the RFC 3339 fixed-offset range ±23:59.
 pub fn FixedOffsetDateTime::from_datetime_and_offset(
   utc : DateTime,
   offset_seconds : Int,
-) -> FixedOffsetDateTime {
+) -> FixedOffsetDateTime raise TempoError {
+  validate_fixed_offset_seconds(offset_seconds)
   { utc, offset_seconds }
+}
+
+///|
+fn validate_fixed_offset_seconds(offset_seconds : Int) -> Unit raise TempoError {
+  if offset_seconds % 60 != 0 {
+    raise TempoError("fixed offset must be whole-minute granularity")
+  }
+  let max_offset_seconds = 23 * 3600 + 59 * 60
+  if offset_seconds < -max_offset_seconds || offset_seconds > max_offset_seconds {
+    raise TempoError("fixed offset out of RFC 3339 range ±23:59")
+  }
 }
 
 ///|
@@ -2299,7 +2314,7 @@ pub fn FixedOffsetDateTime::parse(
   s : String,
 ) -> FixedOffsetDateTime raise TempoError {
   let (utc, offset_seconds) = parse_rfc3339_parts(s)
-  { utc, offset_seconds }
+  FixedOffsetDateTime::from_datetime_and_offset(utc, offset_seconds)
 }
 
 ///|

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -1,5 +1,5 @@
 // tempo — UTC-only date/time library for MoonBit
-// Types: Date, Time, DateTime, Duration
+// Types: Date, Time, DateTime, FixedOffsetDateTime, Duration
 // Features: Unix timestamps, RFC 3339 parsing/formatting, arithmetic
 
 ///|
@@ -310,6 +310,18 @@ pub struct DateTime {
   date : Date
   time : Time
 } derive(Eq, Compare, Hash)
+
+///|
+/// A UTC instant paired with a fixed numeric display offset.
+///
+/// `DateTime` is tempo's primary timestamp type. Use `FixedOffsetDateTime` only
+/// for wire formats and interop surfaces where a timestamp carries an explicit
+/// numeric offset but no IANA time zone. The stored instant is normalized UTC;
+/// the offset is retained only as a display hint.
+pub struct FixedOffsetDateTime {
+  priv utc : DateTime
+  priv offset_seconds : Int
+} derive(Eq, Compare)
 
 ///|
 /// A DateTime interval with a half-open end instant: `[start, end)`.
@@ -850,6 +862,32 @@ pub fn DateTime::to_date(self : DateTime) -> Date {
 /// Return the time component of this `DateTime`.
 pub fn DateTime::to_time(self : DateTime) -> Time {
   self.time
+}
+
+///|
+/// Bundle a UTC instant with a fixed numeric display offset in seconds.
+///
+/// The `utc` argument is the UTC instant and is stored as-is. `DateTime`
+/// remains tempo's primary timestamp type; this wrapper is for wire-format
+/// interop when a timestamp carries an explicit numeric offset but no IANA
+/// time zone.
+pub fn FixedOffsetDateTime::from_datetime_and_offset(
+  utc : DateTime,
+  offset_seconds : Int,
+) -> FixedOffsetDateTime {
+  { utc, offset_seconds }
+}
+
+///|
+/// Return the stored UTC instant.
+pub fn FixedOffsetDateTime::to_utc(self : FixedOffsetDateTime) -> DateTime {
+  self.utc
+}
+
+///|
+/// Return the retained fixed display offset in seconds.
+pub fn FixedOffsetDateTime::offset_seconds(self : FixedOffsetDateTime) -> Int {
+  self.offset_seconds
 }
 
 ///|
@@ -1727,14 +1765,65 @@ fn fmt_frac(ns : Int) -> String {
 /// Note: expanded-year output (years outside 0000–9999) cannot be round-tripped
 /// through `DateTime::parse`, which accepts only 4-digit positive years (RFC 3339).
 pub fn DateTime::format(self : DateTime) -> String {
-  let d = self.date
-  let t = self.time
+  format_datetime_without_zone(self) + "Z"
+}
+
+///|
+fn format_datetime_without_zone(dt : DateTime) -> String {
+  let d = dt.date
+  let t = dt.time
   let base = "\{pad4_year(d.year)}-\{pad2(d.month)}-\{pad2(d.day)}T\{pad2(t.hour)}:\{pad2(t.minute)}:\{pad2(t.second)}"
   if t.nanosecond == 0 {
-    base + "Z"
+    base
   } else {
-    base + "." + fmt_frac(t.nanosecond) + "Z"
+    base + "." + fmt_frac(t.nanosecond)
   }
+}
+
+///|
+fn shift_datetime_by_seconds(dt : DateTime, offset_seconds : Int) -> DateTime {
+  let t = dt.time
+  let seconds_of_day = t.hour * 3600 + t.minute * 60 + t.second
+  let total_seconds = seconds_of_day.to_int64() + offset_seconds.to_int64()
+  let day_delta = floor_div64(total_seconds, 86400L).to_int()
+  let local_second = floor_mod64(total_seconds, 86400L).to_int()
+  {
+    date: dt.date.add_days(day_delta),
+    time: {
+      hour: local_second / 3600,
+      minute: local_second % 3600 / 60,
+      second: local_second % 60,
+      nanosecond: t.nanosecond,
+    },
+  }
+}
+
+///|
+fn format_offset_suffix(offset_seconds : Int) -> String {
+  if offset_seconds == 0 {
+    "Z"
+  } else {
+    let offset = offset_seconds.to_int64()
+    let sign = if offset < 0L { "-" } else { "+" }
+    let abs_seconds = if offset < 0L { -offset } else { offset }
+    let total_minutes = abs_seconds / 60L
+    let hours = (total_minutes / 60L).to_int()
+    let minutes = (total_minutes % 60L).to_int()
+    "\{sign}\{pad2(hours)}:\{pad2(minutes)}"
+  }
+}
+
+///|
+/// Format the local wall-clock time with the retained fixed offset.
+///
+/// The local wall-clock is computed as the stored UTC instant plus
+/// `offset_seconds`; the fixed offset suffix is `Z` for zero and `+HH:MM` /
+/// `-HH:MM` otherwise. This is for RFC 3339-style interop only; `DateTime`
+/// remains the primary UTC timestamp type.
+pub fn FixedOffsetDateTime::format(self : FixedOffsetDateTime) -> String {
+  let wall_clock = shift_datetime_by_seconds(self.utc, self.offset_seconds)
+  format_datetime_without_zone(wall_clock) +
+  format_offset_suffix(self.offset_seconds)
 }
 
 ///|
@@ -1882,6 +1971,11 @@ pub impl Show for Time with fn output(self, logger) {
 
 ///|
 pub impl Show for DateTime with fn output(self, logger) {
+  logger.write_string(self.format())
+}
+
+///|
+pub impl Show for FixedOffsetDateTime with fn output(self, logger) {
   logger.write_string(self.format())
 }
 
@@ -2192,6 +2286,24 @@ pub fn Duration::parse_iso(s : String) -> Duration raise TempoError {
 /// Parse an RFC 3339 / ISO 8601 datetime string.
 /// Fixed numeric offsets are accepted and normalized to UTC.
 pub fn DateTime::parse(s : String) -> DateTime raise TempoError {
+  let (utc, _) = parse_rfc3339_parts(s)
+  utc
+}
+
+///|
+/// Parse an RFC 3339 datetime string, retaining the explicit fixed offset.
+///
+/// The stored instant is normalized UTC. The parsed numeric offset is retained
+/// only for formatting/interoperability; it is not an IANA time zone.
+pub fn FixedOffsetDateTime::parse(
+  s : String,
+) -> FixedOffsetDateTime raise TempoError {
+  let (utc, offset_seconds) = parse_rfc3339_parts(s)
+  { utc, offset_seconds }
+}
+
+///|
+fn parse_rfc3339_parts(s : String) -> (DateTime, Int) raise TempoError {
   let v = s.view()
   let (year, v) = parse_digits(v, 4)
   let v = consume(v, '-')
@@ -2241,7 +2353,7 @@ pub fn DateTime::parse(s : String) -> DateTime raise TempoError {
   let date = Date::new(year, month, day)
   let time = Time::new(hour, minute, second, nanosecond)
   let base = { date, time }
-  if offset_minutes == 0 {
+  let utc = if offset_minutes == 0 {
     base
   } else {
     let total_min = (hour * 60 + minute - offset_minutes).to_int64()
@@ -2257,6 +2369,7 @@ pub fn DateTime::parse(s : String) -> DateTime raise TempoError {
       ),
     }
   }
+  (utc, offset_minutes * 60)
 }
 
 ///|

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -321,7 +321,7 @@ pub struct DateTime {
 pub struct FixedOffsetDateTime {
   priv utc : DateTime
   priv offset_seconds : Int
-} derive(Eq, Compare)
+} derive(Eq, Compare, Hash)
 
 ///|
 /// A DateTime interval with a half-open end instant: `[start, end)`.
@@ -1835,6 +1835,16 @@ fn format_offset_suffix(offset_seconds : Int) -> String {
 /// `offset_seconds`; the fixed offset suffix is `Z` for zero and `+HH:MM` /
 /// `-HH:MM` otherwise. This is for RFC 3339-style interop only; `DateTime`
 /// remains the primary UTC timestamp type.
+///
+/// Note: formatting can abort when the local-time projection carries the year
+/// near the `Int` extremes — it uses the same bounded-`Int` date arithmetic
+/// (`Date::add_days`) and year padding (`pad4_year`) as `Date`/`DateTime`.
+/// This is a known implementation boundary shared with those primitives, not a
+/// property unique to `FixedOffsetDateTime`; it lies outside the current
+/// arithmetic envelope (year ≈ ±2.1e9, far past where `Date::add_days` already
+/// overflows). Ordinary timestamps and calendar dates are unaffected. The real
+/// fix is a core-arithmetic hardening pass (checked / Int64 epoch-day
+/// intermediates), tracked in tempo-oj8.
 pub fn FixedOffsetDateTime::format(self : FixedOffsetDateTime) -> String {
   let wall_clock = shift_datetime_by_seconds(self.utc, self.offset_seconds)
   format_datetime_without_zone(wall_clock) +

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -1195,6 +1195,32 @@ test "FixedOffsetDateTime::from_datetime_and_offset rejects invalid offsets" {
 }
 
 ///|
+test "FixedOffsetDateTime::format supports max positive offset" {
+  let s = "2024-07-21T00:00:00+23:59"
+  let dt = @tempo.FixedOffsetDateTime::parse(s)
+  assert_eq(dt.offset_seconds(), 23 * 3600 + 59 * 60)
+  assert_eq(dt.to_utc().format(), "2024-07-20T00:01:00Z")
+  assert_eq(dt.format(), s)
+  assert_eq(
+    @tempo.FixedOffsetDateTime::from_datetime_and_offset(
+      @tempo.DateTime::parse("2024-07-20T00:01:00Z"),
+      23 * 3600 + 59 * 60,
+    ).format(),
+    s,
+  )
+}
+
+///|
+test "panic format_extreme_year_boundary" {
+  let dt = @tempo.DateTime::new(
+    @tempo.Date::new(@int.MAX_VALUE, 12, 31),
+    @tempo.Time::new(23, 59, 0, 0),
+  )
+  @tempo.FixedOffsetDateTime::from_datetime_and_offset(dt, 60).format()
+  |> ignore
+}
+
+///|
 test "FixedOffsetDateTime Eq and Compare include offset" {
   let utc = @tempo.DateTime::parse("2024-07-21T21:11:00Z")
   let a = @tempo.FixedOffsetDateTime::from_datetime_and_offset(utc, -14400)
@@ -1203,6 +1229,14 @@ test "FixedOffsetDateTime Eq and Compare include offset" {
   assert_eq(a == b, true)
   assert_eq(a == c, false)
   assert_eq(a < c, true)
+}
+
+///|
+test "FixedOffsetDateTime is a hash collection key" {
+  let dt = @tempo.FixedOffsetDateTime::parse("2024-07-21T17:11:00-04:00")
+  let values : Map[@tempo.FixedOffsetDateTime, String] = {}
+  values.set(dt, "offset")
+  assert_true(values.get(dt) == Some("offset"))
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -1178,6 +1178,23 @@ test "FixedOffsetDateTime::from_datetime_and_offset bundles instant and offset" 
 }
 
 ///|
+test "FixedOffsetDateTime::from_datetime_and_offset rejects invalid offsets" {
+  let utc = @tempo.DateTime::parse("2024-07-21T21:11:00Z")
+  assert_true(
+    (try? @tempo.FixedOffsetDateTime::from_datetime_and_offset(utc, 61))
+    is Err(_),
+  )
+  assert_true(
+    (try? @tempo.FixedOffsetDateTime::from_datetime_and_offset(utc, 86400))
+    is Err(_),
+  )
+  assert_true(
+    (try? @tempo.FixedOffsetDateTime::from_datetime_and_offset(utc, -86400))
+    is Err(_),
+  )
+}
+
+///|
 test "FixedOffsetDateTime Eq and Compare include offset" {
   let utc = @tempo.DateTime::parse("2024-07-21T21:11:00Z")
   let a = @tempo.FixedOffsetDateTime::from_datetime_and_offset(utc, -14400)

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -1137,6 +1137,71 @@ test "DateTime::parse offset normalization matches Z equivalent" {
 }
 
 ///|
+test "FixedOffsetDateTime::parse retains negative offset" {
+  let dt = @tempo.FixedOffsetDateTime::parse("2024-07-21T17:11:00-04:00")
+  assert_eq(dt.offset_seconds(), -14400)
+  assert_eq(dt.to_utc().format(), "2024-07-21T21:11:00Z")
+  assert_eq(dt.format(), "2024-07-21T17:11:00-04:00")
+}
+
+///|
+test "FixedOffsetDateTime::parse retains positive offset" {
+  let dt = @tempo.FixedOffsetDateTime::parse("2024-07-21T17:11:00+05:30")
+  assert_eq(dt.offset_seconds(), 19800)
+  assert_eq(dt.to_utc().format(), "2024-07-21T11:41:00Z")
+  assert_eq(dt.format(), "2024-07-21T17:11:00+05:30")
+}
+
+///|
+test "FixedOffsetDateTime::parse retains UTC offset" {
+  let dt = @tempo.FixedOffsetDateTime::parse("2024-07-21T17:11:00Z")
+  assert_eq(dt.offset_seconds(), 0)
+  assert_eq(dt.to_utc().format(), "2024-07-21T17:11:00Z")
+  assert_eq(dt.format(), "2024-07-21T17:11:00Z")
+}
+
+///|
+test "FixedOffsetDateTime::parse round-trips offset strings" {
+  let negative = "2024-07-21T17:11:00-04:00"
+  let positive = "2024-07-21T17:11:00+05:30"
+  assert_eq(@tempo.FixedOffsetDateTime::parse(negative).format(), negative)
+  assert_eq(@tempo.FixedOffsetDateTime::parse(positive).format(), positive)
+}
+
+///|
+test "FixedOffsetDateTime::from_datetime_and_offset bundles instant and offset" {
+  let utc = @tempo.DateTime::parse("2024-07-21T21:11:00Z")
+  let dt = @tempo.FixedOffsetDateTime::from_datetime_and_offset(utc, -14400)
+  assert_eq(dt.to_utc(), utc)
+  assert_eq(dt.offset_seconds(), -14400)
+  assert_eq(dt.format(), "2024-07-21T17:11:00-04:00")
+}
+
+///|
+test "FixedOffsetDateTime Eq and Compare include offset" {
+  let utc = @tempo.DateTime::parse("2024-07-21T21:11:00Z")
+  let a = @tempo.FixedOffsetDateTime::from_datetime_and_offset(utc, -14400)
+  let b = @tempo.FixedOffsetDateTime::from_datetime_and_offset(utc, -14400)
+  let c = @tempo.FixedOffsetDateTime::from_datetime_and_offset(utc, 0)
+  assert_eq(a == b, true)
+  assert_eq(a == c, false)
+  assert_eq(a < c, true)
+}
+
+///|
+test "FixedOffsetDateTime::format carries local date across midnight" {
+  let utc = @tempo.DateTime::parse("2024-07-21T23:30:00Z")
+  let dt = @tempo.FixedOffsetDateTime::from_datetime_and_offset(utc, 7200)
+  assert_eq(dt.format(), "2024-07-22T01:30:00+02:00")
+}
+
+///|
+test "Show FixedOffsetDateTime writes formatted value" {
+  let dt = @tempo.FixedOffsetDateTime::parse("2024-07-21T17:11:00-04:00")
+  inspect(dt, content="2024-07-21T17:11:00-04:00")
+}
+
+///|
 test "DateTime::parse rejects out-of-range offset" {
   assert_true(
     (try? @tempo.DateTime::parse("2024-03-15T12:34:56+24:00")) is Err(_),


### PR DESCRIPTION
Closes tempo-1ms.2.

Adds an opaque FixedOffsetDateTime for RFC 3339 interop where a timestamp carries an explicit numeric offset but no IANA zone. DateTime remains the primary UTC type; FixedOffsetDateTime stores the normalized UTC instant plus the retained display offset.

Refactors DateTime::parse through a shared private parse_rfc3339_parts helper so DateTime behavior stays unchanged while FixedOffsetDateTime::parse retains offset_seconds. Adds blackbox coverage for negative, positive, and Z offsets; round trips; constructor/accessors; offset-sensitive Eq/Compare; day-boundary local formatting; and manual Show.

Verification: moon info && moon fmt; moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native.

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: 568d02e02ca497071370d0670f1d81a83f5f1e54
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: 568d02e02ca497071370d0670f1d81a83f5f1e54
  - output tail:
```text
Total tests: 240, passed: 240, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: 568d02e02ca497071370d0670f1d81a83f5f1e54
  - output tail:
```text
Total tests: 240, passed: 240, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: 568d02e02ca497071370d0670f1d81a83f5f1e54
  - output tail:
```text
Total tests: 240, passed: 240, failed: 0.
```