### PR TITLE
Add Date quarter and year accessors

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -28,12 +28,15 @@ pub fn Date::add_years(Self, Int) -> Self
 pub fn Date::clamp(Self, Self, Self) -> Self
 pub fn Date::day_of_week(Self) -> Int
 pub fn Date::day_of_year(Self) -> Int
+pub fn Date::days_in_year(Self) -> Int
 pub fn Date::days_until(Self, Self) -> Int
 pub fn Date::end_of_month(Self) -> Self
+pub fn Date::end_of_quarter(Self) -> Self
 pub fn Date::end_of_year(Self) -> Self
 pub fn Date::format(Self) -> String
 pub fn Date::is_after(Self, Self) -> Bool
 pub fn Date::is_before(Self, Self) -> Bool
+pub fn Date::is_leap(Self) -> Bool
 pub fn Date::max(Self, Self) -> Self
 pub fn Date::min(Self, Self) -> Self
 pub fn Date::month_enum(Self) -> Month
@@ -44,7 +47,9 @@ pub fn Date::nth_weekday_of_month(Int, Int, Weekday, Int) -> Self raise TempoErr
 pub fn Date::parse(String) -> Self raise TempoError
 pub fn Date::previous(Self, Weekday) -> Self
 pub fn Date::previous_or_same(Self, Weekday) -> Self
+pub fn Date::quarter(Self) -> Int
 pub fn Date::start_of_month(Self) -> Self
+pub fn Date::start_of_quarter(Self) -> Self
 pub fn Date::start_of_year(Self) -> Self
 pub fn Date::weekday(Self) -> Weekday
 pub fn Date::with_day(Self, Int) -> Self raise TempoError

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -507,6 +507,54 @@ pub fn Date::end_of_year(self : Date) -> Date {
 }
 
 ///|
+/// Calendar quarter number in 1..4.
+pub fn Date::quarter(self : Date) -> Int {
+  match self.month {
+    1 | 2 | 3 => 1
+    4 | 5 | 6 => 2
+    7 | 8 | 9 => 3
+    10 | 11 | 12 => 4
+    _ => abort("Date month out of range")
+  }
+}
+
+///|
+/// `true` if this date's year is a leap year.
+pub fn Date::is_leap(self : Date) -> Bool {
+  is_leap_year(self.year)
+}
+
+///|
+/// Number of days in this date's calendar year.
+pub fn Date::days_in_year(self : Date) -> Int {
+  if self.is_leap() {
+    366
+  } else {
+    365
+  }
+}
+
+///|
+/// Return the first day of this date's calendar quarter.
+pub fn Date::start_of_quarter(self : Date) -> Date {
+  let month = match self.quarter() {
+    1 => 1
+    2 => 4
+    3 => 7
+    4 => 10
+    _ => abort("Date::quarter returned out-of-range quarter")
+  }
+  { ..self, month, day: 1 }
+}
+
+///|
+/// Return the last day of this date's calendar quarter.
+pub fn Date::end_of_quarter(self : Date) -> Date {
+  let month = self.start_of_quarter().month + 2
+  { ..self, month, day: days_in_month(self.year, month) }
+}
+
+///|
 /// Add a signed number of calendar days to this date (proleptic Gregorian).
 pub fn Date::add_days(self : Date, days : Int) -> Date {
   let base = days_from_civil(self.year, self.month, self.day)

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -208,6 +208,59 @@ test "Date boundary adjusters for month and year starts" {
 }
 
 ///|
+test "Date quarter boundary accessors" {
+  assert_eq(@tempo.Date::new(2024, 3, 31).quarter(), 1)
+  assert_eq(@tempo.Date::new(2024, 4, 1).quarter(), 2)
+  assert_eq(@tempo.Date::new(2024, 7, 1).quarter(), 3)
+  assert_eq(@tempo.Date::new(2024, 10, 1).quarter(), 4)
+}
+
+///|
+test "Date days_in_year and is_leap accessors" {
+  assert_eq(@tempo.Date::new(2024, 1, 1).days_in_year(), 366)
+  assert_eq(@tempo.Date::new(2023, 1, 1).days_in_year(), 365)
+  assert_eq(@tempo.Date::new(2024, 1, 1).is_leap(), true)
+  assert_eq(@tempo.Date::new(1900, 1, 1).is_leap(), false)
+  assert_eq(@tempo.Date::new(2000, 1, 1).is_leap(), true)
+}
+
+///|
+test "Date quarter boundary adjusters" {
+  assert_eq(
+    @tempo.Date::new(2024, 2, 10).start_of_quarter(),
+    @tempo.Date::new(2024, 1, 1),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 2, 10).end_of_quarter(),
+    @tempo.Date::new(2024, 3, 31),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 5, 15).start_of_quarter(),
+    @tempo.Date::new(2024, 4, 1),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 5, 15).end_of_quarter(),
+    @tempo.Date::new(2024, 6, 30),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 8, 20).start_of_quarter(),
+    @tempo.Date::new(2024, 7, 1),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 8, 20).end_of_quarter(),
+    @tempo.Date::new(2024, 9, 30),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 11, 30).start_of_quarter(),
+    @tempo.Date::new(2024, 10, 1),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 11, 30).end_of_quarter(),
+    @tempo.Date::new(2024, 12, 31),
+  )
+}
+
+///|
 test "DateTime boundary adjusters preserve time of day" {
   let dt = @tempo.DateTime::parse("2024-03-15T14:30:00Z")
   assert_eq(dt.start_of_month().format(), "2024-03-01T14:30:00Z")


### PR DESCRIPTION
Closes bead tempo-bra.3.

Adds Date::quarter, Date::days_in_year, Date::is_leap, Date::start_of_quarter, and Date::end_of_quarter.

Tests cover quarter boundary months, leap-year/year-day accessors, and quarter start/end dates for all four quarters.

Verification:
- moon info && moon fmt
- moon fmt --check
- moon test --target wasm-gc
- moon test --target js
- moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: d4b7bbf406c06ede52c1c5dc7ab9c10f2d0c65ea
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: d4b7bbf406c06ede52c1c5dc7ab9c10f2d0c65ea
  - output tail:
```text
Total tests: 247, passed: 247, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: d4b7bbf406c06ede52c1c5dc7ab9c10f2d0c65ea
  - output tail:
```text
Total tests: 247, passed: 247, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: d4b7bbf406c06ede52c1c5dc7ab9c10f2d0c65ea
  - output tail:
```text
Total tests: 247, passed: 247, failed: 0.
```