### PR TITLE
feat: add YearMonth calendar type

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -251,6 +251,21 @@ pub fn Weekday::previous(Self) -> Self
 pub fn Weekday::to_int(Self) -> Int
 pub impl Show for Weekday
 
+pub(all) struct YearMonth {
+  year : Int
+  month : Int
+} derive(Compare, Eq, Hash)
+pub fn YearMonth::at_day(Self, Int) -> Date raise TempoError
+pub fn YearMonth::at_end_of_month(Self) -> Date
+pub fn YearMonth::format(Self) -> String
+pub fn YearMonth::length(Self) -> Int
+pub fn YearMonth::month_enum(Self) -> Month
+pub fn YearMonth::new(Int, Int) -> Self raise TempoError
+pub fn YearMonth::parse(String) -> Self raise TempoError
+pub fn YearMonth::plus_months(Self, Int) -> Self
+pub fn YearMonth::plus_years(Self, Int) -> Self
+pub impl Show for YearMonth
+
 // Type aliases
 
 // Traits

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -825,9 +825,10 @@ pub fn Date::format(self : Date) -> String {
 }
 
 ///|
-/// Format this year-month as `YYYY-MM` for four-digit years. Negative years and
-/// years >= 10000 use the same expanded-year output as `Date::format`; those
-/// expanded strings cannot be round-tripped through `YearMonth::parse`.
+/// Format this year-month using the same year text as `Date::format`, followed
+/// by `-` and a zero-padded month. Years in 0..9999 produce `YYYY-MM`; negative
+/// years and years >= 10000 produce expanded-year strings that cannot be
+/// round-tripped through `YearMonth::parse`.
 pub fn YearMonth::format(self : YearMonth) -> String {
   "\{pad4_year(self.year)}-\{pad2(self.month)}"
 }

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -825,7 +825,9 @@ pub fn Date::format(self : Date) -> String {
 }
 
 ///|
-/// Format this year-month as 'YYYY-MM'.
+/// Format this year-month as `YYYY-MM` for four-digit years. Negative years and
+/// years >= 10000 use the same expanded-year output as `Date::format`; those
+/// expanded strings cannot be round-tripped through `YearMonth::parse`.
 pub fn YearMonth::format(self : YearMonth) -> String {
   "\{pad4_year(self.year)}-\{pad2(self.month)}"
 }

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -26,6 +26,13 @@ pub struct Date {
 } derive(Eq, Compare, Hash)
 
 ///|
+/// A calendar year and month in the proleptic Gregorian calendar.
+pub(all) struct YearMonth {
+  year : Int
+  month : Int // 1–12
+} derive(Eq, Compare, Hash)
+
+///|
 /// A calendar date interval with an inclusive end date: `[start, end]`.
 ///
 /// This mirrors NodaTime's DateInterval-vs-Interval convention split:
@@ -420,6 +427,15 @@ pub fn Date::new(year : Int, month : Int, day : Int) -> Date raise TempoError {
   { year, month, day }
 }
 
+///|
+/// Create a `YearMonth`, validating that `month` is 1–12.
+pub fn YearMonth::new(year : Int, month : Int) -> YearMonth raise TempoError {
+  if month < 1 || month > 12 {
+    raise TempoError("month \{month} out of range 1–12")
+  }
+  { year, month }
+}
+
 // ─── Date arithmetic ──────────────────────────────────────────────────────────
 
 ///|
@@ -456,6 +472,24 @@ pub fn Date::add_months(self : Date, months : Int) -> Date {
 /// non-leap target years.
 pub fn Date::add_years(self : Date, years : Int) -> Date {
   self.add_months64(years.to_int64() * 12L)
+}
+
+///|
+fn YearMonth::plus_months64(self : YearMonth, months : Int64) -> YearMonth {
+  let (year, month) = shift_year_month(self.year, self.month, months)
+  { year, month }
+}
+
+///|
+/// Add a signed number of calendar months to this year-month.
+pub fn YearMonth::plus_months(self : YearMonth, months : Int) -> YearMonth {
+  self.plus_months64(months.to_int64())
+}
+
+///|
+/// Add a signed number of calendar years to this year-month.
+pub fn YearMonth::plus_years(self : YearMonth, years : Int) -> YearMonth {
+  self.plus_months64(years.to_int64() * 12L)
 }
 
 ///|
@@ -623,6 +657,33 @@ pub fn Date::month_enum(self : Date) -> Month {
 }
 
 ///|
+/// Calendar month for this year-month.
+pub fn YearMonth::month_enum(self : YearMonth) -> Month {
+  match Month::from_int(self.month) {
+    Some(month) => month
+    None => abort("YearMonth month out of range")
+  }
+}
+
+///|
+/// Number of days in this year-month.
+pub fn YearMonth::length(self : YearMonth) -> Int {
+  self.month_enum().days_in(self.year)
+}
+
+///|
+/// Return the date in this year-month at `day`, validating the day.
+pub fn YearMonth::at_day(self : YearMonth, day : Int) -> Date raise TempoError {
+  Date::new(self.year, self.month, day)
+}
+
+///|
+/// Return the last date in this year-month.
+pub fn YearMonth::at_end_of_month(self : YearMonth) -> Date {
+  { year: self.year, month: self.month, day: self.length() }
+}
+
+///|
 /// Day of year in 1..366 (1 = January 1).
 pub fn Date::day_of_year(self : Date) -> Int {
   let y = self.year
@@ -744,9 +805,29 @@ pub fn Date::parse(s : String) -> Date raise TempoError {
 }
 
 ///|
+/// Parse a calendar year-month in 'YYYY-MM' format.
+pub fn YearMonth::parse(s : String) -> YearMonth raise TempoError {
+  let v = s.view()
+  let (year, v) = parse_digits(v, 4)
+  let v = consume(v, '-')
+  let (month, v) = parse_digits(v, 2)
+  match v {
+    [] => ()
+    _ => raise TempoError("unexpected trailing characters")
+  }
+  YearMonth::new(year, month)
+}
+
+///|
 /// Format this date as 'YYYY-MM-DD'.
 pub fn Date::format(self : Date) -> String {
   "\{pad4(self.year)}-\{pad2(self.month)}-\{pad2(self.day)}"
+}
+
+///|
+/// Format this year-month as 'YYYY-MM'.
+pub fn YearMonth::format(self : YearMonth) -> String {
+  "\{pad4_year(self.year)}-\{pad2(self.month)}"
 }
 
 ///|
@@ -1987,6 +2068,11 @@ pub impl Show for Date with fn output(self, logger) {
   logger.write_string(
     "\{pad4_year(self.year)}-\{pad2(self.month)}-\{pad2(self.day)}",
   )
+}
+
+///|
+pub impl Show for YearMonth with fn output(self, logger) {
+  logger.write_string(self.format())
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -577,6 +577,15 @@ test "YearMonth::format parse round-trip and Show" {
 }
 
 ///|
+test "YearMonth::parse rejects malformed or out-of-range input" {
+  assert_true((try? @tempo.YearMonth::parse("2024-00")) is Err(_))
+  assert_true((try? @tempo.YearMonth::parse("2024-13")) is Err(_))
+  assert_true((try? @tempo.YearMonth::parse("2024-2")) is Err(_))
+  assert_true((try? @tempo.YearMonth::parse("2024-02x")) is Err(_))
+  assert_true((try? @tempo.YearMonth::parse("abcd-01")) is Err(_))
+}
+
+///|
 test "YearMonth Compare orders chronologically" {
   assert_eq(
     @tempo.YearMonth::new(2024, 1) < @tempo.YearMonth::new(2024, 2),

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -508,6 +508,97 @@ test "Month Show output" {
 }
 
 ///|
+test "YearMonth::new valid exposes fields and month enum" {
+  let ym = @tempo.YearMonth::new(2024, 2)
+  assert_eq(ym.year, 2024)
+  assert_eq(ym.month, 2)
+  assert_true(ym.month_enum() == @tempo.February)
+}
+
+///|
+test "YearMonth::new rejects invalid months" {
+  assert_true((try? @tempo.YearMonth::new(2024, 0)) is Err(_))
+  assert_true((try? @tempo.YearMonth::new(2024, 13)) is Err(_))
+}
+
+///|
+test "YearMonth::length is leap-aware" {
+  assert_eq(@tempo.YearMonth::new(2024, 2).length(), 29)
+  assert_eq(@tempo.YearMonth::new(2023, 2).length(), 28)
+}
+
+///|
+test "YearMonth::at_day and at_end_of_month" {
+  let feb = @tempo.YearMonth::new(2024, 2)
+  assert_eq(feb.at_day(29), @tempo.Date::new(2024, 2, 29))
+  assert_true((try? @tempo.YearMonth::new(2023, 2).at_day(29)) is Err(_))
+  assert_eq(feb.at_end_of_month(), @tempo.Date::new(2024, 2, 29))
+  assert_eq(
+    @tempo.YearMonth::new(2023, 4).at_end_of_month(),
+    @tempo.Date::new(2023, 4, 30),
+  )
+}
+
+///|
+test "YearMonth::plus_months crosses year boundaries" {
+  assert_eq(
+    @tempo.YearMonth::new(2024, 11).plus_months(3),
+    @tempo.YearMonth::new(2025, 2),
+  )
+  assert_eq(
+    @tempo.YearMonth::new(2024, 2).plus_months(-3),
+    @tempo.YearMonth::new(2023, 11),
+  )
+}
+
+///|
+test "YearMonth::plus_years preserves month with Int64 intermediate" {
+  assert_eq(
+    @tempo.YearMonth::new(2024, 2).plus_years(1),
+    @tempo.YearMonth::new(2025, 2),
+  )
+  assert_eq(
+    @tempo.YearMonth::new(2024, 2).plus_years(-1),
+    @tempo.YearMonth::new(2023, 2),
+  )
+  assert_eq(
+    @tempo.YearMonth::new(2024, 1).plus_years(178_956_971),
+    @tempo.YearMonth::new(178958995, 1),
+  )
+}
+
+///|
+test "YearMonth::format parse round-trip and Show" {
+  let ym = @tempo.YearMonth::new(2024, 2)
+  assert_eq(ym.format(), "2024-02")
+  assert_eq(@tempo.YearMonth::parse("2024-02"), ym)
+  assert_eq(@tempo.YearMonth::parse(ym.format()), ym)
+  inspect(ym, content="2024-02")
+}
+
+///|
+test "YearMonth Compare orders chronologically" {
+  assert_eq(
+    @tempo.YearMonth::new(2024, 1) < @tempo.YearMonth::new(2024, 2),
+    true,
+  )
+  assert_eq(
+    @tempo.YearMonth::new(2023, 12) < @tempo.YearMonth::new(2024, 1),
+    true,
+  )
+}
+
+///|
+test "YearMonth is a hash collection key" {
+  let values : Map[@tempo.YearMonth, String] = {}
+  let feb = @tempo.YearMonth::new(2024, 2)
+  values.set(feb, "leap-february")
+  assert_true(
+    values.get(@tempo.YearMonth::new(2024, 2)) == Some("leap-february"),
+  )
+}
+
+///|
 test "Date typed weekday and month accessors" {
   let d = @tempo.Date::new(2024, 3, 15)
   assert_eq(d.weekday().to_int(), d.day_of_week())


### PR DESCRIPTION
Closes bead tempo-0fu.7.

Adds the YearMonth value type for year+month calendar operations, including validation, month enum/length helpers, Date construction helpers, Int64-backed month/year arithmetic, YYYY-MM parse/format, and manual Show output.

Verification:
- moon info && moon fmt
- moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: f58ffd1256ba5afe050aa53c10ca767b9ef20fc5
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: f58ffd1256ba5afe050aa53c10ca767b9ef20fc5
  - output tail:
```text
Total tests: 253, passed: 253, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: f58ffd1256ba5afe050aa53c10ca767b9ef20fc5
  - output tail:
```text
Total tests: 253, passed: 253, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: f58ffd1256ba5afe050aa53c10ca767b9ef20fc5
  - output tail:
```text
Total tests: 253, passed: 253, failed: 0.
```