### PR TITLE
feat: add ISO 8601 week dates

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -32,8 +32,12 @@ pub fn Date::days_until(Self, Self) -> Int
 pub fn Date::end_of_month(Self) -> Self
 pub fn Date::end_of_year(Self) -> Self
 pub fn Date::format(Self) -> String
+pub fn Date::format_iso_week(Self) -> String
+pub fn Date::from_iso_week(Int, Int, Int) -> Self raise TempoError
 pub fn Date::is_after(Self, Self) -> Bool
 pub fn Date::is_before(Self, Self) -> Bool
+pub fn Date::iso_week(Self) -> Int
+pub fn Date::iso_week_year(Self) -> Int
 pub fn Date::max(Self, Self) -> Self
 pub fn Date::min(Self, Self) -> Self
 pub fn Date::month_enum(Self) -> Month

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -539,6 +539,69 @@ pub fn Date::weekday(self : Date) -> Weekday {
 }
 
 ///|
+fn iso_week1_monday(week_year : Int) -> Date {
+  let jan4 = { year: week_year, month: 1, day: 4 }
+  jan4.add_days(1 - jan4.weekday().number_from_monday())
+}
+
+///|
+fn iso_weeks_in_year(week_year : Int) -> Int {
+  let jan1 = { year: week_year, month: 1, day: 1 }
+  let jan1_weekday = jan1.weekday().number_from_monday()
+  if jan1_weekday == 4 || (jan1_weekday == 3 && is_leap_year(week_year)) {
+    53
+  } else {
+    52
+  }
+}
+
+///|
+/// ISO 8601 week-numbering year for this date.
+///
+/// This can differ from the calendar year near New Year; for example,
+/// 2021-01-01 belongs to ISO week year 2020.
+pub fn Date::iso_week_year(self : Date) -> Int {
+  self.add_days(4 - self.weekday().number_from_monday()).year
+}
+
+///|
+/// ISO 8601 week number in 1..53 for this date.
+pub fn Date::iso_week(self : Date) -> Int {
+  let week_year = self.iso_week_year()
+  let week1 = iso_week1_monday(week_year)
+  week1.days_until(self) / 7 + 1
+}
+
+///|
+/// Create a date from an ISO 8601 week date.
+///
+/// `week_year` is the ISO week-numbering year, `week` is 1..52 or 1..53
+/// depending on that year, and `weekday` is Monday = 1 through Sunday = 7.
+pub fn Date::from_iso_week(
+  week_year : Int,
+  week : Int,
+  weekday : Int,
+) -> Date raise TempoError {
+  let max_week = iso_weeks_in_year(week_year)
+  if week < 1 || week > max_week {
+    raise TempoError("ISO week \{week} out of range for \{week_year}")
+  }
+  let wd = match Weekday::from_int(weekday) {
+    Some(wd) => wd
+    None => raise TempoError("ISO weekday \{weekday} out of range 1–7")
+  }
+  let days = (week - 1).to_int64() * 7L +
+    (wd.number_from_monday() - 1).to_int64()
+  iso_week1_monday(week_year).add_days(days.to_int())
+}
+
+///|
+/// Format this date as an ISO 8601 week date: `YYYY-Www-D`.
+pub fn Date::format_iso_week(self : Date) -> String {
+  "\{pad4_year(self.iso_week_year())}-W\{pad2(self.iso_week())}-\{self.weekday().number_from_monday()}"
+}
+
+///|
 fn positive_mod7(n : Int) -> Int {
   (n % 7 + 7) % 7
 }

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -396,6 +396,108 @@ test "Date::day_of_week ISO" {
 }
 
 ///|
+test "Date ISO week-date accessors and format boundary cases" {
+  let new_year_monday = @tempo.Date::new(2024, 1, 1)
+  assert_eq(new_year_monday.iso_week_year(), 2024)
+  assert_eq(new_year_monday.iso_week(), 1)
+  assert_eq(new_year_monday.format_iso_week(), "2024-W01-1")
+  let prior_week_year = @tempo.Date::new(2021, 1, 1)
+  assert_eq(prior_week_year.iso_week_year(), 2020)
+  assert_eq(prior_week_year.iso_week(), 53)
+  assert_eq(prior_week_year.format_iso_week(), "2020-W53-5")
+  let next_week_year = @tempo.Date::new(2024, 12, 30)
+  assert_eq(next_week_year.iso_week_year(), 2025)
+  assert_eq(next_week_year.iso_week(), 1)
+  assert_eq(next_week_year.format_iso_week(), "2025-W01-1")
+  let week_53_end = @tempo.Date::new(2026, 12, 31)
+  assert_eq(week_53_end.iso_week_year(), 2026)
+  assert_eq(week_53_end.iso_week(), 53)
+  assert_eq(week_53_end.format_iso_week(), "2026-W53-4")
+}
+
+///|
+test "Date::from_iso_week known ISO week dates" {
+  assert_eq(
+    @tempo.Date::from_iso_week(2024, 1, 1),
+    @tempo.Date::new(2024, 1, 1),
+  )
+  assert_eq(
+    @tempo.Date::from_iso_week(2020, 53, 5),
+    @tempo.Date::new(2021, 1, 1),
+  )
+  assert_eq(
+    @tempo.Date::from_iso_week(2025, 1, 1),
+    @tempo.Date::new(2024, 12, 30),
+  )
+  assert_eq(
+    @tempo.Date::from_iso_week(2026, 53, 4),
+    @tempo.Date::new(2026, 12, 31),
+  )
+  assert_eq(
+    @tempo.Date::from_iso_week(2024, 21, 3),
+    @tempo.Date::new(2024, 5, 22),
+  )
+}
+
+///|
+test "Date::from_iso_week round-trips boundary dates" {
+  let d = @tempo.Date::new(2015, 12, 31)
+  assert_eq(
+    @tempo.Date::from_iso_week(
+      d.iso_week_year(),
+      d.iso_week(),
+      d.weekday().number_from_monday(),
+    ),
+    d,
+  )
+  let d = @tempo.Date::new(2016, 1, 1)
+  assert_eq(
+    @tempo.Date::from_iso_week(
+      d.iso_week_year(),
+      d.iso_week(),
+      d.weekday().number_from_monday(),
+    ),
+    d,
+  )
+  let d = @tempo.Date::new(2024, 1, 1)
+  assert_eq(
+    @tempo.Date::from_iso_week(
+      d.iso_week_year(),
+      d.iso_week(),
+      d.weekday().number_from_monday(),
+    ),
+    d,
+  )
+  let d = @tempo.Date::new(2024, 12, 30)
+  assert_eq(
+    @tempo.Date::from_iso_week(
+      d.iso_week_year(),
+      d.iso_week(),
+      d.weekday().number_from_monday(),
+    ),
+    d,
+  )
+  let d = @tempo.Date::new(2026, 12, 31)
+  assert_eq(
+    @tempo.Date::from_iso_week(
+      d.iso_week_year(),
+      d.iso_week(),
+      d.weekday().number_from_monday(),
+    ),
+    d,
+  )
+}
+
+///|
+test "Date::from_iso_week rejects invalid week and weekday" {
+  assert_true((try? @tempo.Date::from_iso_week(2021, 53, 1)) is Err(_))
+  assert_true((try? @tempo.Date::from_iso_week(2024, 0, 1)) is Err(_))
+  assert_true((try? @tempo.Date::from_iso_week(2024, 54, 1)) is Err(_))
+  assert_true((try? @tempo.Date::from_iso_week(2024, 1, 0)) is Err(_))
+  assert_true((try? @tempo.Date::from_iso_week(2024, 1, 8)) is Err(_))
+}
+
+///|
 test "Weekday conversion helpers" {
   assert_true(@tempo.Weekday::from_int(1) == Some(@tempo.Monday))
   assert_eq(@tempo.Monday.to_int(), 1)


### PR DESCRIPTION
Closes bead tempo-bra.1.\n\nAdds Date ISO week-date support: iso_week_year, iso_week, from_iso_week validation, and YYYY-Www-D formatting. Includes boundary reference cases, round-trips, invalid week/weekday checks, and updated generated interface.\n\nVerification:\n- moon fmt --check\n- moon test --target wasm-gc\n- moon test --target js\n- moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: b567751ecc2cc13ae1e0030e048018d76917f657
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: b567751ecc2cc13ae1e0030e048018d76917f657
  - output tail:
```text
Total tests: 248, passed: 248, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: b567751ecc2cc13ae1e0030e048018d76917f657
  - output tail:
```text
Total tests: 248, passed: 248, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: b567751ecc2cc13ae1e0030e048018d76917f657
  - output tail:
```text
Total tests: 248, passed: 248, failed: 0.
```