### PR TITLE
feat: add Date ordinal support

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -32,6 +32,8 @@ pub fn Date::days_until(Self, Self) -> Int
 pub fn Date::end_of_month(Self) -> Self
 pub fn Date::end_of_year(Self) -> Self
 pub fn Date::format(Self) -> String
+pub fn Date::format_ordinal(Self) -> String
+pub fn Date::from_ordinal(Int, Int) -> Self raise TempoError
 pub fn Date::is_after(Self, Self) -> Bool
 pub fn Date::is_before(Self, Self) -> Bool
 pub fn Date::max(Self, Self) -> Self

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -420,6 +420,20 @@ pub fn Date::new(year : Int, month : Int, day : Int) -> Date raise TempoError {
   { year, month, day }
 }
 
+///|
+/// Create a `Date` from `year` and day-of-year in 1..365, or 1..366 for a
+/// leap year.
+pub fn Date::from_ordinal(
+  year : Int,
+  day_of_year : Int,
+) -> Date raise TempoError {
+  let days_in_year = if is_leap_year(year) { 366 } else { 365 }
+  if day_of_year < 1 || day_of_year > days_in_year {
+    raise TempoError("day_of_year \{day_of_year} out of range for year \{year}")
+  }
+  Date::new(year, 1, 1).add_days(day_of_year - 1)
+}
+
 // ─── Date arithmetic ──────────────────────────────────────────────────────────
 
 ///|
@@ -747,6 +761,12 @@ pub fn Date::parse(s : String) -> Date raise TempoError {
 /// Format this date as 'YYYY-MM-DD'.
 pub fn Date::format(self : Date) -> String {
   "\{pad4(self.year)}-\{pad2(self.month)}-\{pad2(self.day)}"
+}
+
+///|
+/// Format this date as 'YYYY-DDD', where `DDD` is day-of-year in 001..366.
+pub fn Date::format_ordinal(self : Date) -> String {
+  "\{pad4_year(self.year)}-\{pad3(self.day_of_year())}"
 }
 
 ///|
@@ -1696,6 +1716,19 @@ pub fn DateTime::until(self : DateTime, later : DateTime) -> Duration {
 ///|
 fn pad2(n : Int) -> String {
   if n < 10 {
+    "0\{n}"
+  } else {
+    "\{n}"
+  }
+}
+
+// Zero-pad an integer to 3 digits.
+
+///|
+fn pad3(n : Int) -> String {
+  if n < 10 {
+    "00\{n}"
+  } else if n < 100 {
     "0\{n}"
   } else {
     "\{n}"

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -764,7 +764,8 @@ pub fn Date::format(self : Date) -> String {
 }
 
 ///|
-/// Format this date as 'YYYY-DDD', where `DDD` is day-of-year in 001..366.
+/// Format this date as an ordinal date using ISO 8601 expanded-year output
+/// (see `pad4_year`), followed by day-of-year in 001..366.
 pub fn Date::format_ordinal(self : Date) -> String {
   "\{pad4_year(self.year)}-\{pad3(self.day_of_year())}"
 }

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -593,6 +593,43 @@ test "Date::day_of_year" {
 }
 
 ///|
+test "Date::from_ordinal valid days" {
+  assert_eq(@tempo.Date::from_ordinal(2024, 1), @tempo.Date::new(2024, 1, 1))
+  assert_eq(
+    @tempo.Date::from_ordinal(2024, 366),
+    @tempo.Date::new(2024, 12, 31),
+  )
+  assert_eq(@tempo.Date::from_ordinal(2024, 60), @tempo.Date::new(2024, 2, 29))
+}
+
+///|
+test "Date::from_ordinal invalid days" {
+  assert_true((try? @tempo.Date::from_ordinal(2023, 366)) is Err(_))
+  assert_true((try? @tempo.Date::from_ordinal(2024, 0)) is Err(_))
+}
+
+///|
+test "Date::from_ordinal is inverse of day_of_year" {
+  let jan1 = @tempo.Date::new(2024, 1, 1)
+  assert_eq(@tempo.Date::from_ordinal(jan1.year, jan1.day_of_year()), jan1)
+  let leap_day = @tempo.Date::new(2024, 2, 29)
+  assert_eq(
+    @tempo.Date::from_ordinal(leap_day.year, leap_day.day_of_year()),
+    leap_day,
+  )
+  let leap_dec31 = @tempo.Date::new(2024, 12, 31)
+  assert_eq(
+    @tempo.Date::from_ordinal(leap_dec31.year, leap_dec31.day_of_year()),
+    leap_dec31,
+  )
+  let common_dec31 = @tempo.Date::new(2023, 12, 31)
+  assert_eq(
+    @tempo.Date::from_ordinal(common_dec31.year, common_dec31.day_of_year()),
+    common_dec31,
+  )
+}
+
+///|
 test "Date::days_until" {
   let a = @tempo.Date::new(2024, 3, 1)
   let b = @tempo.Date::new(2024, 3, 15)
@@ -629,6 +666,17 @@ test "Date::parse valid" {
 test "Date::format" {
   let d = @tempo.Date::new(2024, 3, 5)
   assert_eq(d.format(), "2024-03-05")
+}
+
+///|
+test "Date::format_ordinal" {
+  assert_eq(@tempo.Date::new(2024, 1, 1).format_ordinal(), "2024-001")
+  assert_eq(@tempo.Date::new(2024, 7, 20).format_ordinal(), "2024-202")
+  let d = @tempo.Date::new(2024, 7, 20)
+  assert_eq(
+    @tempo.Date::from_ordinal(d.year, d.day_of_year()).format_ordinal(),
+    d.format_ordinal(),
+  )
 }
 
 ///|


### PR DESCRIPTION
Closes bead tempo-bra.2.

Adds Date::from_ordinal(year, day_of_year) with leap-year validation and Date::format_ordinal() for YYYY-DDD output. Tests cover leap/common boundaries, invalid ordinal days, day_of_year inverse checks, and ordinal formatting round-trip.

Verification:
- moon info && moon fmt
- moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: b037be6c9c95628e81c2a3f359923642c71dd1ad
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: b037be6c9c95628e81c2a3f359923642c71dd1ad
  - output tail:
```text
Total tests: 248, passed: 248, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: b037be6c9c95628e81c2a3f359923642c71dd1ad
  - output tail:
```text
Total tests: 248, passed: 248, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: b037be6c9c95628e81c2a3f359923642c71dd1ad
  - output tail:
```text
Total tests: 248, passed: 248, failed: 0.
```