### PR TITLE
Add calendar Period

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -24,6 +24,7 @@ pub struct Date {
 } derive(Compare, Eq, Hash)
 pub fn Date::add_days(Self, Int) -> Self
 pub fn Date::add_months(Self, Int) -> Self
+pub fn Date::add_period(Self, Period) -> Self raise TempoError
 pub fn Date::add_years(Self, Int) -> Self
 pub fn Date::clamp(Self, Self, Self) -> Self
 pub fn Date::day_of_week(Self) -> Int
@@ -46,6 +47,7 @@ pub fn Date::previous(Self, Weekday) -> Self
 pub fn Date::previous_or_same(Self, Weekday) -> Self
 pub fn Date::start_of_month(Self) -> Self
 pub fn Date::start_of_year(Self) -> Self
+pub fn Date::until(Self, Self) -> Period
 pub fn Date::weekday(Self) -> Weekday
 pub fn Date::with_day(Self, Int) -> Self raise TempoError
 pub fn Date::with_month(Self, Int) -> Self raise TempoError
@@ -196,6 +198,30 @@ pub fn Month::next(Self) -> Self
 pub fn Month::previous(Self) -> Self
 pub fn Month::to_int(Self) -> Int
 pub impl Show for Month
+
+pub(all) struct Period {
+  years : Int
+  months : Int
+  days : Int
+} derive(Eq, Hash)
+pub fn Period::days(Self) -> Int
+pub fn Period::format(Self) -> String
+pub fn Period::is_zero(Self) -> Bool
+pub fn Period::minus(Self, Self) -> Self raise TempoError
+pub fn Period::months(Self) -> Int
+pub fn Period::negated(Self) -> Self raise TempoError
+pub fn Period::normalized(Self) -> Self
+pub fn Period::of(Int, Int, Int) -> Self
+pub fn Period::of_days(Int) -> Self
+pub fn Period::of_months(Int) -> Self
+pub fn Period::of_weeks(Int) -> Self raise TempoError
+pub fn Period::of_years(Int) -> Self
+pub fn Period::parse(String) -> Self raise TempoError
+pub fn Period::plus(Self, Self) -> Self raise TempoError
+pub fn Period::to_total_months(Self) -> Int64
+pub fn Period::years(Self) -> Int
+pub fn Period::zero() -> Self
+pub impl Show for Period
 
 pub(all) enum RoundMode {
   Floor

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -47,7 +47,7 @@ pub fn Date::previous(Self, Weekday) -> Self
 pub fn Date::previous_or_same(Self, Weekday) -> Self
 pub fn Date::start_of_month(Self) -> Self
 pub fn Date::start_of_year(Self) -> Self
-pub fn Date::until(Self, Self) -> Period
+pub fn Date::until(Self, Self) -> Period raise TempoError
 pub fn Date::weekday(Self) -> Weekday
 pub fn Date::with_day(Self, Int) -> Self raise TempoError
 pub fn Date::with_month(Self, Int) -> Self raise TempoError
@@ -210,7 +210,7 @@ pub fn Period::is_zero(Self) -> Bool
 pub fn Period::minus(Self, Self) -> Self raise TempoError
 pub fn Period::months(Self) -> Int
 pub fn Period::negated(Self) -> Self raise TempoError
-pub fn Period::normalized(Self) -> Self
+pub fn Period::normalized(Self) -> Self raise TempoError
 pub fn Period::of(Int, Int, Int) -> Self
 pub fn Period::of_days(Int) -> Self
 pub fn Period::of_months(Int) -> Self

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -878,22 +878,17 @@ pub fn Date::days_until(self : Date, other : Date) -> Int {
 /// clamping and the day-borrow behavior used by `java.time.LocalDate.until`.
 pub fn Date::until(self : Date, other : Date) -> Period raise TempoError {
   let mut total_months = other.proleptic_month() - self.proleptic_month()
-  let mut days = other.day - self.day
-  if total_months > 0L && days < 0 {
+  let provisional_days = other.day - self.day
+  if total_months > 0L && provisional_days < 0 {
     total_months -= 1L
-    let adjusted = self.add_months64_checked(total_months)
-    days = int64_to_int_checked(
-      other.epoch_day() - adjusted.epoch_day(),
-      "period days",
-    )
-  } else if total_months < 0L && days > 0 {
+  } else if total_months < 0L && provisional_days > 0 {
     total_months += 1L
-    let adjusted = self.add_months64_checked(total_months)
-    days = int64_to_int_checked(
-      other.epoch_day() - adjusted.epoch_day(),
-      "period days",
-    )
   }
+  let anchor = self.add_months64_checked(total_months)
+  let days = int64_to_int_checked(
+    other.epoch_day() - anchor.epoch_day(),
+    "period days",
+  )
   {
     years: int64_to_int_checked(total_months / 12L, "period years"),
     months: int64_to_int_checked(total_months % 12L, "period months"),

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -26,6 +26,18 @@ pub struct Date {
 } derive(Eq, Compare, Hash)
 
 ///|
+/// A calendar-aware date period stored as exact year, month, and day fields.
+///
+/// This is a calendar-field vector, not an elapsed-time scalar. It is never
+/// auto-canonicalized: fifteen months stays fifteen months, and thirty days
+/// never becomes one month.
+pub(all) struct Period {
+  years : Int
+  months : Int
+  days : Int
+} derive(Eq, Hash)
+
+///|
 /// A calendar date interval with an inclusive end date: `[start, end]`.
 ///
 /// This mirrors NodaTime's DateInterval-vs-Interval convention split:
@@ -420,6 +432,145 @@ pub fn Date::new(year : Int, month : Int, day : Int) -> Date raise TempoError {
   { year, month, day }
 }
 
+// ─── Period constructors and arithmetic ──────────────────────────────────────
+
+///|
+fn int64_to_int_checked(
+  value : Int64,
+  context : String,
+) -> Int raise TempoError {
+  if value < @int.MIN_VALUE.to_int64() || value > @int.MAX_VALUE.to_int64() {
+    raise TempoError("\{context} overflows Int")
+  }
+  value.to_int()
+}
+
+///|
+fn checked_int_add(a : Int, b : Int, context : String) -> Int raise TempoError {
+  int64_to_int_checked(a.to_int64() + b.to_int64(), context)
+}
+
+///|
+fn checked_int_sub(a : Int, b : Int, context : String) -> Int raise TempoError {
+  int64_to_int_checked(a.to_int64() - b.to_int64(), context)
+}
+
+///|
+fn checked_int_neg(a : Int, context : String) -> Int raise TempoError {
+  if a == @int.MIN_VALUE {
+    raise TempoError("\{context} overflows Int")
+  }
+  -a
+}
+
+///|
+/// Create a `Period`, storing the year, month, and day fields exactly.
+pub fn Period::of(years : Int, months : Int, days : Int) -> Period {
+  { years, months, days }
+}
+
+///|
+/// Create a `Period` with only a year field.
+pub fn Period::of_years(years : Int) -> Period {
+  { years, months: 0, days: 0 }
+}
+
+///|
+/// Create a `Period` with only a month field.
+pub fn Period::of_months(months : Int) -> Period {
+  { years: 0, months, days: 0 }
+}
+
+///|
+/// Create a `Period` with only a day field.
+pub fn Period::of_days(days : Int) -> Period {
+  { years: 0, months: 0, days }
+}
+
+///|
+/// Create a `Period` from whole weeks, stored as days.
+pub fn Period::of_weeks(weeks : Int) -> Period raise TempoError {
+  let days = int64_to_int_checked(weeks.to_int64() * 7L, "period weeks")
+  { years: 0, months: 0, days }
+}
+
+///|
+/// The zero period.
+pub fn Period::zero() -> Period {
+  { years: 0, months: 0, days: 0 }
+}
+
+///|
+/// Year field accessor.
+pub fn Period::years(self : Period) -> Int {
+  self.years
+}
+
+///|
+/// Month field accessor.
+pub fn Period::months(self : Period) -> Int {
+  self.months
+}
+
+///|
+/// Day field accessor.
+pub fn Period::days(self : Period) -> Int {
+  self.days
+}
+
+///|
+/// Normalize the month field into years. Days are left untouched.
+pub fn Period::normalized(self : Period) -> Period {
+  let total_months = self.to_total_months()
+  {
+    years: (total_months / 12L).to_int(),
+    months: (total_months % 12L).to_int(),
+    days: self.days,
+  }
+}
+
+///|
+/// Total months represented by the year and month fields. Days are ignored.
+pub fn Period::to_total_months(self : Period) -> Int64 {
+  self.years.to_int64() * 12L + self.months.to_int64()
+}
+
+///|
+/// Add two periods field-wise, without normalization.
+pub fn Period::plus(self : Period, other : Period) -> Period raise TempoError {
+  {
+    years: checked_int_add(self.years, other.years, "period years"),
+    months: checked_int_add(self.months, other.months, "period months"),
+    days: checked_int_add(self.days, other.days, "period days"),
+  }
+}
+
+///|
+/// Subtract two periods field-wise, without normalization.
+pub fn Period::minus(self : Period, other : Period) -> Period raise TempoError {
+  {
+    years: checked_int_sub(self.years, other.years, "period years"),
+    months: checked_int_sub(self.months, other.months, "period months"),
+    days: checked_int_sub(self.days, other.days, "period days"),
+  }
+}
+
+///|
+/// Negate each period field, without normalization.
+pub fn Period::negated(self : Period) -> Period raise TempoError {
+  {
+    years: checked_int_neg(self.years, "period years"),
+    months: checked_int_neg(self.months, "period months"),
+    days: checked_int_neg(self.days, "period days"),
+  }
+}
+
+///|
+/// `true` when all three fields are zero.
+pub fn Period::is_zero(self : Period) -> Bool {
+  self.years == 0 && self.months == 0 && self.days == 0
+}
+
 // ─── Date arithmetic ──────────────────────────────────────────────────────────
 
 ///|
@@ -456,6 +607,16 @@ pub fn Date::add_months(self : Date, months : Int) -> Date {
 /// non-leap target years.
 pub fn Date::add_years(self : Date, years : Int) -> Date {
   self.add_months64(years.to_int64() * 12L)
+}
+
+///|
+/// Add a calendar period to this date.
+///
+/// Years and months are combined into one month adjustment first, using the
+/// same end-of-month clamping as `Date::add_months`; days are added afterward.
+pub fn Date::add_period(self : Date, period : Period) -> Date raise TempoError {
+  let result = self.add_months64(period.to_total_months()).add_days(period.days)
+  Date::new(result.year, result.month, result.day)
 }
 
 ///|
@@ -632,11 +793,45 @@ pub fn Date::day_of_year(self : Date) -> Int {
 }
 
 ///|
+fn Date::epoch_day(self : Date) -> Int64 {
+  days_from_civil(self.year, self.month, self.day)
+}
+
+///|
+fn Date::proleptic_month(self : Date) -> Int64 {
+  self.year.to_int64() * 12L + (self.month - 1).to_int64()
+}
+
+///|
 /// Calendar days from `self` to `other` (`other` minus `self`). Negative if `other` is earlier.
 pub fn Date::days_until(self : Date, other : Date) -> Int {
-  let a = days_from_civil(self.year, self.month, self.day)
-  let b = days_from_civil(other.year, other.month, other.day)
+  let a = self.epoch_day()
+  let b = other.epoch_day()
   (b - a).to_int()
+}
+
+///|
+/// Calendar period from this date until `other`.
+///
+/// The result round-trips through `Date::add_period`, including month-end
+/// clamping and the day-borrow behavior used by `java.time.LocalDate.until`.
+pub fn Date::until(self : Date, other : Date) -> Period {
+  let mut total_months = other.proleptic_month() - self.proleptic_month()
+  let mut days = other.day - self.day
+  if total_months > 0L && days < 0 {
+    total_months -= 1L
+    let adjusted = self.add_months64(total_months)
+    days = (other.epoch_day() - adjusted.epoch_day()).to_int()
+  } else if total_months < 0L && days > 0 {
+    total_months += 1L
+    let adjusted = self.add_months64(total_months)
+    days = (other.epoch_day() - adjusted.epoch_day()).to_int()
+  }
+  {
+    years: (total_months / 12L).to_int(),
+    months: (total_months % 12L).to_int(),
+    days,
+  }
 }
 
 ///|
@@ -1864,6 +2059,27 @@ pub fn Time::format(self : Time) -> String {
 }
 
 ///|
+/// Format this calendar period as ISO 8601 date-period components.
+pub fn Period::format(self : Period) -> String {
+  if self.is_zero() {
+    "P0D"
+  } else {
+    let buf = StringBuilder()
+    buf.write_string("P")
+    if self.years != 0 {
+      buf.write_string("\{self.years}Y")
+    }
+    if self.months != 0 {
+      buf.write_string("\{self.months}M")
+    }
+    if self.days != 0 {
+      buf.write_string("\{self.days}D")
+    }
+    buf.to_string()
+  }
+}
+
+///|
 /// Format this fixed-length duration as a canonical ISO 8601 duration string.
 ///
 /// Calendar units (years and months) are not representable as a fixed
@@ -2005,6 +2221,11 @@ pub impl Show for FixedOffsetDateTime with fn output(self, logger) {
 }
 
 ///|
+pub impl Show for Period with fn output(self, logger) {
+  logger.write_string(self.format())
+}
+
+///|
 pub impl Show for Duration with fn output(self, logger) {
   logger.write_string(self.to_string_repr())
 }
@@ -2123,6 +2344,111 @@ fn parse_frac_ns(view : StringView) -> (Int, StringView) raise TempoError {
         }
         break (ns, v)
       }
+    }
+  }
+}
+
+///|
+fn parse_period_number(view : StringView) -> (Int, StringView) raise TempoError {
+  let (negative, v) = match view {
+    ['-', .. rest] => (true, rest)
+    ['+', .. rest] => (false, rest)
+    _ => (false, view)
+  }
+  let limit = if negative {
+    @int.MAX_VALUE.to_int64() + 1L
+  } else {
+    @int.MAX_VALUE.to_int64()
+  }
+  for v = v, count = 0, acc = 0L {
+    match v {
+      ['0'..='9' as c, .. rest] => {
+        let digit = (c.to_int() - '0').to_int64()
+        if acc > (limit - digit) / 10L {
+          raise TempoError("period component overflows Int")
+        }
+        continue rest, count + 1, acc * 10L + digit
+      }
+      _ => {
+        if count == 0 {
+          raise TempoError("expected period component digits")
+        }
+        let value = if negative {
+          if acc == limit {
+            @int.MIN_VALUE
+          } else {
+            (0L - acc).to_int()
+          }
+        } else {
+          acc.to_int()
+        }
+        break (value, v)
+      }
+    }
+  }
+}
+
+///|
+fn reject_period_order() -> Unit raise TempoError {
+  raise TempoError("period components are repeated or out of order")
+}
+
+///|
+/// Parse an ISO 8601 date-period string in the `PnYnMnD` subset.
+///
+/// Week notation (`PnW`) is accepted and stored as days. Time components and
+/// any `T` separator are rejected.
+pub fn Period::parse(s : String) -> Period raise TempoError {
+  let v = match s.view() {
+    ['P', .. rest] => rest
+    [c, ..] => raise TempoError("expected 'P', got '\{c}'")
+    [] => raise TempoError("unexpected end of input, expected 'P'")
+  }
+  for v = v, years = 0, months = 0, days = 0, saw_component = false, rank = 0 {
+    match v {
+      [] =>
+        if saw_component {
+          break { years, months, days }
+        } else {
+          raise TempoError("expected period component")
+        }
+      ['T', ..] => raise TempoError("period time components are not supported")
+      ['+' | '-' | '0'..='9', ..] => {
+        let (amount, rest) = parse_period_number(v)
+        match rest {
+          ['Y', .. rest] => {
+            if rank >= 1 {
+              reject_period_order()
+            }
+            continue rest, amount, months, days, true, 1
+          }
+          ['M', .. rest] => {
+            if rank >= 2 {
+              reject_period_order()
+            }
+            continue rest, years, amount, days, true, 2
+          }
+          ['D', .. rest] => {
+            if rank >= 3 {
+              reject_period_order()
+            }
+            continue rest, years, months, amount, true, 3
+          }
+          ['W', .. rest] => {
+            if saw_component {
+              raise TempoError("period week component cannot be combined")
+            }
+            match rest {
+              [] => break Period::of_weeks(amount)
+              _ => raise TempoError("period week component cannot be combined")
+            }
+          }
+          [] =>
+            raise TempoError("unexpected end of input, expected period unit")
+          [c, ..] => raise TempoError("expected period unit, got '\{c}'")
+        }
+      }
+      [c, ..] => raise TempoError("expected period component, got '\{c}'")
     }
   }
 }

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -402,6 +402,25 @@ fn civil_from_days(z : Int64) -> (Int, Int, Int) {
   (y, m, d)
 }
 
+///|
+fn civil_from_days_checked(z : Int64) -> (Int, Int, Int) raise TempoError {
+  let z = match checked_i64_add(z, 719468L) {
+    Some(z) => z
+    None => raise TempoError("date epoch day overflows Int64")
+  }
+  let era = floor_div64(z, 146097L)
+  let doe = (z - era * 146097L).to_int() // 0..146096
+  let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365 // 0..399
+  let y64 = yoe.to_int64() + era * 400L
+  let doy = doe - (365 * yoe + yoe / 4 - yoe / 100) // 0..365
+  let mp = (5 * doy + 2) / 153 // 0..11
+  let d = doy - (153 * mp + 2) / 5 + 1 // 1..31
+  let m = if mp < 10 { mp + 3 } else { mp - 9 } // 1..12
+  let y64 = if m <= 2 { y64 + 1L } else { y64 }
+  let y = int64_to_int_checked(y64, "date year")
+  (y, m, d)
+}
+
 // Howard Hinnant's days_from_civil: (year, month, day) → days-since-epoch
 
 ///|
@@ -520,11 +539,11 @@ pub fn Period::days(self : Period) -> Int {
 
 ///|
 /// Normalize the month field into years. Days are left untouched.
-pub fn Period::normalized(self : Period) -> Period {
+pub fn Period::normalized(self : Period) -> Period raise TempoError {
   let total_months = self.to_total_months()
   {
-    years: (total_months / 12L).to_int(),
-    months: (total_months % 12L).to_int(),
+    years: int64_to_int_checked(total_months / 12L, "period years"),
+    months: int64_to_int_checked(total_months % 12L, "period months"),
     days: self.days,
   }
 }
@@ -590,6 +609,36 @@ fn Date::add_months64(self : Date, months : Int64) -> Date {
 }
 
 ///|
+fn checked_shift_year_month(
+  year : Int,
+  month : Int,
+  months : Int64,
+) -> (Int, Int) raise TempoError {
+  let base = year.to_int64() * 12L + (month - 1).to_int64()
+  let total = match checked_i64_add(base, months) {
+    Some(total) => total
+    None => raise TempoError("date month adjustment overflows Int64")
+  }
+  let new_year = int64_to_int_checked(
+    floor_div64(total, 12L),
+    "date month adjustment year",
+  )
+  let new_month = floor_mod64(total, 12L).to_int() + 1
+  (new_year, new_month)
+}
+
+///|
+fn Date::add_months64_checked(
+  self : Date,
+  months : Int64,
+) -> Date raise TempoError {
+  let (year, month) = checked_shift_year_month(self.year, self.month, months)
+  let max_day = days_in_month(year, month)
+  let day = if self.day > max_day { max_day } else { self.day }
+  Date::new(year, month, day)
+}
+
+///|
 /// Add a signed number of calendar months to this date.
 ///
 /// If the original day does not exist in the target month, the result is
@@ -615,8 +664,9 @@ pub fn Date::add_years(self : Date, years : Int) -> Date {
 /// Years and months are combined into one month adjustment first, using the
 /// same end-of-month clamping as `Date::add_months`; days are added afterward.
 pub fn Date::add_period(self : Date, period : Period) -> Date raise TempoError {
-  let result = self.add_months64(period.to_total_months()).add_days(period.days)
-  Date::new(result.year, result.month, result.day)
+  self
+  .add_months64_checked(period.to_total_months())
+  .add_days_checked(period.days)
 }
 
 ///|
@@ -673,6 +723,17 @@ pub fn Date::add_days(self : Date, days : Int) -> Date {
   let base = days_from_civil(self.year, self.month, self.day)
   let (y, m, d) = civil_from_days(base + days.to_int64())
   { year: y, month: m, day: d }
+}
+
+///|
+fn Date::add_days_checked(self : Date, days : Int) -> Date raise TempoError {
+  let base = days_from_civil(self.year, self.month, self.day)
+  let target = match checked_i64_add(base, days.to_int64()) {
+    Some(target) => target
+    None => raise TempoError("date day adjustment overflows Int64")
+  }
+  let (y, m, d) = civil_from_days_checked(target)
+  Date::new(y, m, d)
 }
 
 ///|
@@ -815,21 +876,27 @@ pub fn Date::days_until(self : Date, other : Date) -> Int {
 ///
 /// The result round-trips through `Date::add_period`, including month-end
 /// clamping and the day-borrow behavior used by `java.time.LocalDate.until`.
-pub fn Date::until(self : Date, other : Date) -> Period {
+pub fn Date::until(self : Date, other : Date) -> Period raise TempoError {
   let mut total_months = other.proleptic_month() - self.proleptic_month()
   let mut days = other.day - self.day
   if total_months > 0L && days < 0 {
     total_months -= 1L
-    let adjusted = self.add_months64(total_months)
-    days = (other.epoch_day() - adjusted.epoch_day()).to_int()
+    let adjusted = self.add_months64_checked(total_months)
+    days = int64_to_int_checked(
+      other.epoch_day() - adjusted.epoch_day(),
+      "period days",
+    )
   } else if total_months < 0L && days > 0 {
     total_months += 1L
-    let adjusted = self.add_months64(total_months)
-    days = (other.epoch_day() - adjusted.epoch_day()).to_int()
+    let adjusted = self.add_months64_checked(total_months)
+    days = int64_to_int_checked(
+      other.epoch_day() - adjusted.epoch_day(),
+      "period days",
+    )
   }
   {
-    years: (total_months / 12L).to_int(),
-    months: (total_months % 12L).to_int(),
+    years: int64_to_int_checked(total_months / 12L, "period years"),
+    months: int64_to_int_checked(total_months % 12L, "period months"),
     days,
   }
 }

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -157,6 +157,136 @@ test "Date::add_years avoids Int month overflow" {
 }
 
 ///|
+test "Period stores calendar fields structurally" {
+  let p = @tempo.Period::of(0, 15, 0)
+  assert_eq(p.years, 0)
+  assert_eq(p.months, 15)
+  assert_eq(p.days, 0)
+  assert_eq(p.years(), 0)
+  assert_eq(p.months(), 15)
+  assert_eq(p.days(), 0)
+  assert_eq(@tempo.Period::of_years(2), @tempo.Period::of(2, 0, 0))
+  assert_eq(@tempo.Period::of_months(15), p)
+  assert_eq(@tempo.Period::of_days(30), @tempo.Period::of(0, 0, 30))
+  assert_eq(@tempo.Period::zero(), @tempo.Period::of(0, 0, 0))
+  assert_eq(@tempo.Period::of(0, 15, 0) == @tempo.Period::of(1, 3, 0), false)
+}
+
+///|
+test "Period normalization rolls months only" {
+  assert_eq(
+    @tempo.Period::of(1, 15, 0).normalized(),
+    @tempo.Period::of(2, 3, 0),
+  )
+  assert_eq(
+    @tempo.Period::of(0, 15, 5).normalized(),
+    @tempo.Period::of(1, 3, 5),
+  )
+  assert_eq(
+    @tempo.Period::of(1, -25, 0).normalized(),
+    @tempo.Period::of(-1, -1, 0),
+  )
+  assert_eq(@tempo.Period::of(2, 3, 5).to_total_months(), 27L)
+}
+
+///|
+test "Period field arithmetic is checked and non-normalizing" {
+  assert_eq(
+    @tempo.Period::of(1, 15, 3).plus(@tempo.Period::of(2, -5, 7)),
+    @tempo.Period::of(3, 10, 10),
+  )
+  assert_eq(
+    @tempo.Period::of(1, 15, 3).minus(@tempo.Period::of(2, -5, 7)),
+    @tempo.Period::of(-1, 20, -4),
+  )
+  assert_eq(@tempo.Period::of(1, -2, 3).negated(), @tempo.Period::of(-1, 2, -3))
+  assert_eq(@tempo.Period::zero().is_zero(), true)
+  assert_eq(@tempo.Period::of(0, 0, 1).is_zero(), false)
+  assert_true(
+    (try? @tempo.Period::of(@int.MAX_VALUE, 0, 0).plus(
+      @tempo.Period::of(1, 0, 0),
+    ))
+    is Err(_),
+  )
+  assert_true(
+    (try? @tempo.Period::of(@int.MIN_VALUE, 0, 0).negated()) is Err(_),
+  )
+}
+
+///|
+test "Period of_weeks stores checked days" {
+  assert_eq(@tempo.Period::of_weeks(2), @tempo.Period::of(0, 0, 14))
+  assert_true((try? @tempo.Period::of_weeks(@int.MAX_VALUE)) is Err(_))
+}
+
+///|
+test "Date::add_period applies months before days" {
+  assert_eq(
+    @tempo.Date::new(2024, 1, 31).add_period(@tempo.Period::of(0, 1, 0)),
+    @tempo.Date::new(2024, 2, 29),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 1, 31).add_period(@tempo.Period::of(0, 0, 30)),
+    @tempo.Date::new(2024, 3, 1),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 2, 29).add_period(@tempo.Period::of(0, 13, 0)),
+    @tempo.Date::new(2025, 3, 29),
+  )
+  assert_eq(
+    @tempo.Date::new(2024, 1, 31).add_period(@tempo.Period::of(1, 1, 1)),
+    @tempo.Date::new(2025, 3, 1),
+  )
+}
+
+///|
+test "Date::until returns round-tripping Periods" {
+  let forward = @tempo.Date::new(2024, 1, 31)
+  let forward_end = @tempo.Date::new(2024, 3, 30)
+  let forward_period = forward.until(forward_end)
+  assert_eq(forward.add_period(forward_period), forward_end)
+  assert_eq(forward_period, @tempo.Period::of(0, 1, 30))
+  let negative = @tempo.Date::new(2024, 3, 30)
+  let negative_end = @tempo.Date::new(2024, 1, 31)
+  let negative_period = negative.until(negative_end)
+  assert_eq(negative.add_period(negative_period), negative_end)
+  assert_eq(negative_period, @tempo.Period::of(0, -1, -29))
+}
+
+///|
+test "Period format parse round-trips date components" {
+  assert_eq(@tempo.Period::of(1, 2, 3).format(), "P1Y2M3D")
+  assert_eq(@tempo.Period::zero().format(), "P0D")
+  assert_eq(@tempo.Period::of(-1, -2, -3).format(), "P-1Y-2M-3D")
+  let values = [
+    @tempo.Period::zero(),
+    @tempo.Period::of(1, 2, 3),
+    @tempo.Period::of(-1, -2, -3),
+    @tempo.Period::of(0, 15, 0),
+    @tempo.Period::of(0, 0, -14),
+  ]
+  for p in values {
+    assert_eq(@tempo.Period::parse(p.format()), p)
+  }
+  assert_eq(@tempo.Period::parse("P2W"), @tempo.Period::of(0, 0, 14))
+  assert_eq(@tempo.Period::parse("P-2W"), @tempo.Period::of(0, 0, -14))
+  assert_true((try? @tempo.Period::parse("P1YT2H")) is Err(_))
+  assert_true((try? @tempo.Period::parse("PT2H")) is Err(_))
+  inspect(@tempo.Period::of(1, 2, 3), content="P1Y2M3D")
+}
+
+///|
+test "Period is a hash collection key" {
+  let values : Map[@tempo.Period, String] = {}
+  values.set(@tempo.Period::of(0, 15, 0), "fifteen months")
+  values.set(@tempo.Period::of(1, 3, 0), "one year three months")
+  assert_true(values.get(@tempo.Period::of(0, 15, 0)) == Some("fifteen months"))
+  assert_true(
+    values.get(@tempo.Period::of(1, 3, 0)) == Some("one year three months"),
+  )
+}
+
+///|
 test "Date::with field updaters" {
   let d = @tempo.Date::new(2024, 3, 15)
   assert_eq(d.with_day(1), @tempo.Date::new(2024, 3, 1))

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -190,6 +190,18 @@ test "Period normalization rolls months only" {
 }
 
 ///|
+test "Period normalization raises on Int overflow" {
+  assert_true(
+    (try? @tempo.Period::of(@int.MAX_VALUE, @int.MAX_VALUE, 0).normalized())
+    is Err(_),
+  )
+  assert_true(
+    (try? @tempo.Period::of(@int.MIN_VALUE, @int.MIN_VALUE, 0).normalized())
+    is Err(_),
+  )
+}
+
+///|
 test "Period field arithmetic is checked and non-normalizing" {
   assert_eq(
     @tempo.Period::of(1, 15, 3).plus(@tempo.Period::of(2, -5, 7)),
@@ -240,6 +252,28 @@ test "Date::add_period applies months before days" {
 }
 
 ///|
+test "Date::add_period raises on date overflow" {
+  assert_true(
+    (try? @tempo.Date::new(@int.MAX_VALUE, 12, 31).add_period(
+      @tempo.Period::of_months(1),
+    ))
+    is Err(_),
+  )
+  assert_true(
+    (try? @tempo.Date::new(@int.MIN_VALUE, 1, 1).add_period(
+      @tempo.Period::of_months(-1),
+    ))
+    is Err(_),
+  )
+  assert_true(
+    (try? @tempo.Date::new(@int.MAX_VALUE, 12, 31).add_period(
+      @tempo.Period::of_days(1),
+    ))
+    is Err(_),
+  )
+}
+
+///|
 test "Date::until returns round-tripping Periods" {
   let forward = @tempo.Date::new(2024, 1, 31)
   let forward_end = @tempo.Date::new(2024, 3, 30)
@@ -251,6 +285,22 @@ test "Date::until returns round-tripping Periods" {
   let negative_period = negative.until(negative_end)
   assert_eq(negative.add_period(negative_period), negative_end)
   assert_eq(negative_period, @tempo.Period::of(0, -1, -29))
+}
+
+///|
+test "Date::until raises when Period fields cannot represent distance" {
+  assert_true(
+    (try? @tempo.Date::new(@int.MIN_VALUE, 1, 1).until(
+      @tempo.Date::new(@int.MAX_VALUE, 12, 31),
+    ))
+    is Err(_),
+  )
+  assert_true(
+    (try? @tempo.Date::new(@int.MAX_VALUE, 12, 31).until(
+      @tempo.Date::new(@int.MIN_VALUE, 1, 1),
+    ))
+    is Err(_),
+  )
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -280,11 +280,39 @@ test "Date::until returns round-tripping Periods" {
   let forward_period = forward.until(forward_end)
   assert_eq(forward.add_period(forward_period), forward_end)
   assert_eq(forward_period, @tempo.Period::of(0, 1, 30))
-  let negative = @tempo.Date::new(2024, 3, 30)
-  let negative_end = @tempo.Date::new(2024, 1, 31)
-  let negative_period = negative.until(negative_end)
-  assert_eq(negative.add_period(negative_period), negative_end)
-  assert_eq(negative_period, @tempo.Period::of(0, -1, -29))
+  let backward_clamp = @tempo.Date::new(2023, 3, 30)
+  let backward_clamp_end = @tempo.Date::new(2023, 2, 28)
+  let backward_clamp_period = backward_clamp.until(backward_clamp_end)
+  assert_eq(
+    backward_clamp.add_period(backward_clamp_period),
+    backward_clamp_end,
+  )
+  assert_eq(backward_clamp_period, @tempo.Period::of(0, -1, 0))
+  let backward_leap_clamp = @tempo.Date::new(2024, 3, 30)
+  let backward_leap_clamp_end = @tempo.Date::new(2024, 1, 31)
+  let backward_leap_clamp_period = backward_leap_clamp.until(
+    backward_leap_clamp_end,
+  )
+  assert_eq(
+    backward_leap_clamp.add_period(backward_leap_clamp_period),
+    backward_leap_clamp_end,
+  )
+  assert_eq(backward_leap_clamp_period, @tempo.Period::of(0, -1, -29))
+  let forward_clamp = @tempo.Date::new(2024, 1, 31)
+  let forward_clamp_end = @tempo.Date::new(2024, 3, 1)
+  let forward_clamp_period = forward_clamp.until(forward_clamp_end)
+  assert_eq(forward_clamp.add_period(forward_clamp_period), forward_clamp_end)
+  assert_eq(forward_clamp_period, @tempo.Period::of(0, 1, 1))
+  let negative_non_clamp = @tempo.Date::new(2024, 5, 15)
+  let negative_non_clamp_end = @tempo.Date::new(2024, 3, 10)
+  let negative_non_clamp_period = negative_non_clamp.until(
+    negative_non_clamp_end,
+  )
+  assert_eq(
+    negative_non_clamp.add_period(negative_non_clamp_period),
+    negative_non_clamp_end,
+  )
+  assert_eq(negative_non_clamp_period, @tempo.Period::of(0, -2, -5))
 }
 
 ///|


### PR DESCRIPTION
Closes bead tempo-0fu.8.\n\nAdds a calendar-aware Period field vector with exact years/months/days storage, structural Eq/Hash, manual Show via ISO date-period formatting, checked field arithmetic, normalization over months only, parsing including week notation, and Date::add_period / Date::until following java.time.LocalDate semantics.\n\nVerification: moon fmt --check && moon test --target wasm-gc && moon test --target js && moon test --target native.

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: 626bbaf1db4b20dabc0bfda6817622f891acfca4
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: 626bbaf1db4b20dabc0bfda6817622f891acfca4
  - output tail:
```text
Total tests: 252, passed: 252, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: 626bbaf1db4b20dabc0bfda6817622f891acfca4
  - output tail:
```text
Total tests: 252, passed: 252, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: 626bbaf1db4b20dabc0bfda6817622f891acfca4
  - output tail:
```text
Total tests: 252, passed: 252, failed: 0.
```