### PR TITLE
Add fractional Duration total accessors

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -141,11 +141,14 @@ pub struct Duration {
 pub fn Duration::abs(Self) -> Self
 pub fn Duration::as_days(Self) -> Int64
 pub fn Duration::as_hours(Self) -> Int64
+pub fn Duration::as_hours_f64(Self) -> Double
 pub fn Duration::as_microseconds(Self) -> Int64
 pub fn Duration::as_milliseconds(Self) -> Int64
 pub fn Duration::as_minutes(Self) -> Int64
+pub fn Duration::as_minutes_f64(Self) -> Double
 pub fn Duration::as_nanoseconds(Self) -> Int64
 pub fn Duration::as_seconds(Self) -> Int64
+pub fn Duration::as_seconds_f64(Self) -> Double
 pub fn Duration::as_weeks(Self) -> Int64
 pub fn Duration::checked_add(Self, Self) -> Self?
 pub fn Duration::checked_multiply(Self, Int64) -> Self?

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -1917,15 +1917,42 @@ pub fn Duration::as_seconds(self : Duration) -> Int64 {
 }
 
 ///|
+/// Total seconds in this duration as a `Double`.
+///
+/// `Double` has a ~53-bit mantissa, so magnitudes beyond ~2^53 nanoseconds
+/// (~104 days) lose sub-unit precision.
+pub fn Duration::as_seconds_f64(self : Duration) -> Double {
+  self.nanoseconds.to_double() / 1_000_000_000.0
+}
+
+///|
 /// Total whole minutes in this duration (truncated toward zero).
 pub fn Duration::as_minutes(self : Duration) -> Int64 {
   self.nanoseconds / ns_per_min
 }
 
 ///|
+/// Total minutes in this duration as a `Double`.
+///
+/// `Double` has a ~53-bit mantissa, so magnitudes beyond ~2^53 nanoseconds
+/// (~104 days) lose sub-unit precision.
+pub fn Duration::as_minutes_f64(self : Duration) -> Double {
+  self.nanoseconds.to_double() / 60_000_000_000.0
+}
+
+///|
 /// Total whole hours in this duration (truncated toward zero).
 pub fn Duration::as_hours(self : Duration) -> Int64 {
   self.nanoseconds / ns_per_hour
+}
+
+///|
+/// Total hours in this duration as a `Double`.
+///
+/// `Double` has a ~53-bit mantissa, so magnitudes beyond ~2^53 nanoseconds
+/// (~104 days) lose sub-unit precision.
+pub fn Duration::as_hours_f64(self : Duration) -> Double {
+  self.nanoseconds.to_double() / 3_600_000_000_000.0
 }
 
 ///|

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -1922,7 +1922,7 @@ pub fn Duration::as_seconds(self : Duration) -> Int64 {
 /// `Double` has a ~53-bit mantissa, so magnitudes beyond ~2^53 nanoseconds
 /// (~104 days) lose sub-unit precision.
 pub fn Duration::as_seconds_f64(self : Duration) -> Double {
-  self.nanoseconds.to_double() / 1_000_000_000.0
+  self.nanoseconds.to_double() / ns_per_sec.to_double()
 }
 
 ///|
@@ -1937,7 +1937,7 @@ pub fn Duration::as_minutes(self : Duration) -> Int64 {
 /// `Double` has a ~53-bit mantissa, so magnitudes beyond ~2^53 nanoseconds
 /// (~104 days) lose sub-unit precision.
 pub fn Duration::as_minutes_f64(self : Duration) -> Double {
-  self.nanoseconds.to_double() / 60_000_000_000.0
+  self.nanoseconds.to_double() / ns_per_min.to_double()
 }
 
 ///|
@@ -1952,7 +1952,7 @@ pub fn Duration::as_hours(self : Duration) -> Int64 {
 /// `Double` has a ~53-bit mantissa, so magnitudes beyond ~2^53 nanoseconds
 /// (~104 days) lose sub-unit precision.
 pub fn Duration::as_hours_f64(self : Duration) -> Double {
-  self.nanoseconds.to_double() / 3_600_000_000_000.0
+  self.nanoseconds.to_double() / ns_per_hour.to_double()
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -2063,6 +2063,15 @@ test "Duration::hours" {
 }
 
 ///|
+test "Duration fractional total accessors" {
+  assert_eq(@tempo.Duration::milliseconds(1500L).as_seconds_f64(), 1.5)
+  assert_eq(@tempo.Duration::minutes(90L).as_hours_f64(), 1.5)
+  assert_eq(@tempo.Duration::seconds(30L).as_minutes_f64(), 0.5)
+  assert_eq(@tempo.Duration::milliseconds(-1500L).as_seconds_f64(), -1.5)
+  assert_eq(@tempo.Duration::seconds(0L).as_hours_f64(), 0.0)
+}
+
+///|
 test "Duration op_add" {
   let a = @tempo.Duration::seconds(30L)
   let b = @tempo.Duration::seconds(30L)


### PR DESCRIPTION
Closes tempo-z7j.3. Adds Duration::as_seconds_f64, Duration::as_minutes_f64, and Duration::as_hours_f64 by converting total nanoseconds to Double and dividing by Double unit literals. Includes exact public API tests for fractional, negative, and zero cases.

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: ddf8427e58c8c3cf1dbe6f3022d35cc0917aa031
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: ddf8427e58c8c3cf1dbe6f3022d35cc0917aa031
  - output tail:
```text
Total tests: 285, passed: 285, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: ddf8427e58c8c3cf1dbe6f3022d35cc0917aa031
  - output tail:
```text
Total tests: 285, passed: 285, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: ddf8427e58c8c3cf1dbe6f3022d35cc0917aa031
  - output tail:
```text
Total tests: 285, passed: 285, failed: 0.
```