### PR TITLE
Add DateTime::format_with token DSL

### DIFF
--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -94,6 +94,7 @@ pub fn DateTime::end_of_month(Self) -> Self
 pub fn DateTime::end_of_year(Self) -> Self
 pub fn DateTime::epoch() -> Self
 pub fn DateTime::format(Self) -> String
+pub fn DateTime::format_with(Self, String) -> String raise TempoError
 pub fn DateTime::from_unix_micros(Int64) -> Self
 pub fn DateTime::from_unix_millis(Int64) -> Self
 pub fn DateTime::from_unix_nanos(Int64) -> Self

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -2349,9 +2349,9 @@ pub fn DateTime::format(self : DateTime) -> String {
 /// Format this DateTime with a brace-token pattern.
 ///
 /// Supported tokens are `{YYYY}`, `{MM}`, `{DD}`, `{HH}`, `{mm}`, `{ss}`,
-/// `{fff}`, and `{nnnnnnnnn}`. Text outside tokens is copied literally. Use
-/// `{{` and `}}` to emit literal braces. Unknown or unterminated `{...}` tokens
-/// raise `TempoError`.
+/// `{fff}`, and `{nnnnnnnnn}`. Non-brace text outside tokens is copied
+/// literally. Use `{{` and `}}` to emit literal braces. Unknown tokens and
+/// unmatched braces raise `TempoError`.
 pub fn DateTime::format_with(
   self : DateTime,
   pattern : String,
@@ -2377,9 +2377,13 @@ pub fn DateTime::format_with(
         buf.write_string(format_datetime_pattern_token(self, token))
         i = end + 1
       }
-    } else if pattern[i] == '}' && i + 1 < len && pattern[i + 1] == '}' {
-      buf.write_string("}")
-      i += 2
+    } else if pattern[i] == '}' {
+      if i + 1 < len && pattern[i + 1] == '}' {
+        buf.write_string("}")
+        i += 2
+      } else {
+        raise TempoError("unmatched closing brace in datetime format pattern")
+      }
     } else {
       buf.write_string(pattern[i:i + 1].to_owned())
       i += 1

--- a/src/tempo.mbt
+++ b/src/tempo.mbt
@@ -2346,6 +2346,69 @@ pub fn DateTime::format(self : DateTime) -> String {
 }
 
 ///|
+/// Format this DateTime with a brace-token pattern.
+///
+/// Supported tokens are `{YYYY}`, `{MM}`, `{DD}`, `{HH}`, `{mm}`, `{ss}`,
+/// `{fff}`, and `{nnnnnnnnn}`. Text outside tokens is copied literally. Use
+/// `{{` and `}}` to emit literal braces. Unknown or unterminated `{...}` tokens
+/// raise `TempoError`.
+pub fn DateTime::format_with(
+  self : DateTime,
+  pattern : String,
+) -> String raise TempoError {
+  let buf = StringBuilder()
+  let len = pattern.length()
+  let mut i = 0
+  while i < len {
+    if pattern[i] == '{' {
+      if i + 1 < len && pattern[i + 1] == '{' {
+        buf.write_string("{")
+        i += 2
+      } else {
+        let start = i + 1
+        let mut end = start
+        while end < len && pattern[end] != '}' {
+          end += 1
+        }
+        if end >= len {
+          raise TempoError("unterminated datetime format token")
+        }
+        let token = pattern[start:end].to_owned()
+        buf.write_string(format_datetime_pattern_token(self, token))
+        i = end + 1
+      }
+    } else if pattern[i] == '}' && i + 1 < len && pattern[i + 1] == '}' {
+      buf.write_string("}")
+      i += 2
+    } else {
+      buf.write_string(pattern[i:i + 1].to_owned())
+      i += 1
+    }
+  }
+  buf.to_string()
+}
+
+///|
+fn format_datetime_pattern_token(
+  dt : DateTime,
+  token : String,
+) -> String raise TempoError {
+  let d = dt.date
+  let t = dt.time
+  match token {
+    "YYYY" => pad4_year(d.year)
+    "MM" => pad2(d.month)
+    "DD" => pad2(d.day)
+    "HH" => pad2(t.hour)
+    "mm" => pad2(t.minute)
+    "ss" => pad2(t.second)
+    "fff" => pad3(t.nanosecond / 1_000_000)
+    "nnnnnnnnn" => pad9(t.nanosecond)
+    _ => raise TempoError("unknown datetime format token {\{token}}")
+  }
+}
+
+///|
 fn format_datetime_without_zone(dt : DateTime) -> String {
   let d = dt.date
   let t = dt.time

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -1580,6 +1580,7 @@ test "DateTime::format_with tokens and literals" {
 test "DateTime::format_with rejects unknown token" {
   let dt = @tempo.DateTime::parse("2024-03-15T12:34:56Z")
   assert_true((try? dt.format_with("{ZZ}")) is Err(_))
+  assert_true((try? dt.format_with("{YYYY}}")) is Err(_))
 }
 
 ///|

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -1561,6 +1561,34 @@ test "DateTime::format supports full Int year range" {
 }
 
 ///|
+test "DateTime::format_with tokens and literals" {
+  let dt = @tempo.DateTime::parse("2024-03-15T12:34:56.123456789Z")
+  assert_eq(dt.format_with("{YYYY}-{MM}-{DD}"), "2024-03-15")
+  assert_eq(dt.format_with("{HH}:{mm}:{ss}"), "12:34:56")
+  assert_eq(dt.format_with("{YYYY}/{MM}/{DD} {HH}h{mm}"), "2024/03/15 12h34")
+  assert_eq(dt.format_with("{fff} {nnnnnnnnn}"), "123 123456789")
+  let padded = @tempo.DateTime::parse("2024-03-15T12:34:56.007000009Z")
+  assert_eq(padded.format_with("{fff}/{nnnnnnnnn}"), "007/007000009")
+  let expanded = @tempo.DateTime::new(
+    @tempo.Date::new(-44, 3, 15),
+    @tempo.Time::new(0, 0, 0, 0),
+  )
+  assert_eq(expanded.format_with("{YYYY}-{MM}-{DD}"), "-0044-03-15")
+}
+
+///|
+test "DateTime::format_with rejects unknown token" {
+  let dt = @tempo.DateTime::parse("2024-03-15T12:34:56Z")
+  assert_true((try? dt.format_with("{ZZ}")) is Err(_))
+}
+
+///|
+test "DateTime::format_with escapes braces" {
+  let dt = @tempo.DateTime::parse("2024-03-15T12:34:56Z")
+  assert_eq(dt.format_with("{{x}}"), "{x}")
+}
+
+///|
 test "Time::format no sub-second" {
   let t = @tempo.Time::new(0, 0, 0, 0)
   assert_eq(t.format(), "00:00:00")

--- a/src/tempo_test.mbt
+++ b/src/tempo_test.mbt
@@ -1577,9 +1577,17 @@ test "DateTime::format_with tokens and literals" {
 }
 
 ///|
-test "DateTime::format_with rejects unknown token" {
+test "DateTime::format_with rejects invalid patterns" {
   let dt = @tempo.DateTime::parse("2024-03-15T12:34:56Z")
   assert_true((try? dt.format_with("{ZZ}")) is Err(_))
+  assert_true((try? dt.format_with("a{YYYY")) is Err(_))
+  assert_true((try? dt.format_with("a{")) is Err(_))
+  assert_true((try? dt.format_with("{YYY}")) is Err(_))
+  assert_true((try? dt.format_with("{}")) is Err(_))
+  assert_true((try? dt.format_with("{nnnnnnnn}")) is Err(_))
+  assert_true((try? dt.format_with("{nnnnnnnnnn}")) is Err(_))
+  assert_true((try? dt.format_with("{Mm}")) is Err(_))
+  assert_true((try? dt.format_with("}")) is Err(_))
   assert_true((try? dt.format_with("{YYYY}}")) is Err(_))
 }
 
@@ -1587,6 +1595,8 @@ test "DateTime::format_with rejects unknown token" {
 test "DateTime::format_with escapes braces" {
   let dt = @tempo.DateTime::parse("2024-03-15T12:34:56Z")
   assert_eq(dt.format_with("{{x}}"), "{x}")
+  assert_eq(dt.format_with("{{{YYYY}}}"), "{2024}")
+  assert_eq(dt.format_with("}}"), "}")
 }
 
 ///|


### PR DESCRIPTION
Closes bead tempo-dwz.4.

Adds DateTime::format_with(pattern) for brace-token custom UTC DateTime formatting with literal passthrough, doubled-brace escapes, fixed-width millisecond/nanosecond tokens, and TempoError rejection for unknown tokens.

Verification:
- moon fmt --check
- moon test --target wasm-gc
- moon test --target js
- moon test --target native

## Verification

Generated by Choir from commands executed in the leaf workspace.

- `moon fmt --check`
  - exit: 0
  - head: 9e03938d20574224b6fcd731d603838fcd15c772
  - output tail:
```text
Finished. moon: no work to do
```

- `moon test --target wasm-gc`
  - exit: 0
  - head: 9e03938d20574224b6fcd731d603838fcd15c772
  - output tail:
```text
Total tests: 287, passed: 287, failed: 0.
```

- `moon test --target js`
  - exit: 0
  - head: 9e03938d20574224b6fcd731d603838fcd15c772
  - output tail:
```text
Total tests: 287, passed: 287, failed: 0.
```

- `moon test --target native`
  - exit: 0
  - head: 9e03938d20574224b6fcd731d603838fcd15c772
  - output tail:
```text
Total tests: 287, passed: 287, failed: 0.
```