### PR TITLE
chore(release): v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-08-06
+
 ### Added
 
 - `Debug` is now derived for every public type: `Date`, `Time`, `DateTime`,

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "brickfrog/tempo"
 
-version = "0.8.0"
+version = "0.8.1"
 
 readme = "README.mbt.md"
 


### PR DESCRIPTION
Release commit only: rename `## [Unreleased]` → `## [0.8.1] - 2026-08-06`, open a fresh `Unreleased`, bump `moon.mod` to `0.8.1`. No code changes.

Treated as a patch: the release is a compatibility fix for MoonBit v0.10.6, and while the 13 `Debug` impls are technically additive public surface, they exist to restore behavior callers already expected from `assert_eq`.

`moon publish --dry-run` → `202 Accepted, Dry run completed successfully … version 0.8.1`.